### PR TITLE
Fix null pointer for resolving search parameter path

### DIFF
--- a/src/main/java/org/hl7/fhir/definitions/validation/ResourceValidator.java
+++ b/src/main/java/org/hl7/fhir/definitions/validation/ResourceValidator.java
@@ -355,13 +355,17 @@ public class ResourceValidator extends BaseValidator {
                         ElementDefn e;
                         String pp = trimIndexes(path);
                         e = rd.getRoot().getElementForPath(pp, definitions, "Resolving Search Parameter Path", true, false);
-                        for (TypeRef t : e.getTypes()) {
-                            if (t.getName().equals("Reference") || t.getName().equals("canonical")) {
-                                for (String pn : t.getParams()) {
-                                    if (definitions.hasLogicalModel(pn))
-                                        p.getTargets().addAll(definitions.getLogicalModel(pn).getImplementations());
-                                    else
-                                        p.getTargets().add(pn);
+                        if (e == null) {
+                            rule(errors, IssueType.STRUCTURE, rd.getName(), false, "Unable to find element for Search Parameter Path: \"" + pp + "\"");
+                        } else {
+                            for (TypeRef t : e.getTypes()) {
+                                if (t.getName().equals("Reference") || t.getName().equals("canonical")) {
+                                    for (String pn : t.getParams()) {
+                                        if (definitions.hasLogicalModel(pn))
+                                            p.getTargets().addAll(definitions.getLogicalModel(pn).getImplementations());
+                                        else
+                                            p.getTargets().add(pn);
+                                    }
                                 }
                             }
                         }
@@ -372,9 +376,13 @@ public class ResourceValidator extends BaseValidator {
                         ElementDefn e;
                         String pp = trimIndexes(path);
                         e = rd.getRoot().getElementForPath(pp, definitions, "Resolving Search Parameter Path", true, false);
-                        for (TypeRef t : e.getTypes()) {
-                            if (t.getName().equals("Reference")/* || t.getName().equals("canonical")*/) {
-                                rule(errors, IssueType.STRUCTURE, rd.getName(), false, "Parameters of type uri cannot refer to the types Reference or canonical (" + p.getCode() + ")");
+                        if (e == null) {
+                            rule(errors, IssueType.STRUCTURE, rd.getName(), false, "Unable to find element for Search Parameter Path: \"" + pp + "\"");
+                        } else {
+                            for (TypeRef t : e.getTypes()) {
+                                if (t.getName().equals("Reference")/* || t.getName().equals("canonical")*/) {
+                                    rule(errors, IssueType.STRUCTURE, rd.getName(), false, "Parameters of type uri cannot refer to the types Reference or canonical (" + p.getCode() + ")");
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Avoids a NullPointerException when a search path has no results in ResourceValidator and reports the search path.