### PR TITLE
Fix invalid characters in JavaDoc generation

### DIFF
--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/TableGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/TableGenerator.java
@@ -68,9 +68,9 @@ public class TableGenerator extends BaseGenerator {
       gc.addStyledText("This element has or is affected by some invariants", "I", null, null, prefix+"conformance-rules.html#constraints", false);
     }
     if (isInterface) {
-      gc.addStyledText("This is an interface resource", "«I»", null, null, page.getVersion().isR4B() ? null : prefix+"uml.html#interface", false);      
+      gc.addStyledText("This is an interface resource", "Â«IÂ»", null, null, page.getVersion().isR4B() ? null : prefix+"uml.html#interface", false);
     } else if (isAbstract) {
-      gc.addStyledText("This is an abstract type", "«A»", null, null, page.getVersion().isR4B() ? null : prefix+"uml.html#abstract", false);      
+      gc.addStyledText("This is an abstract type", "Â«AÂ»", null, null, page.getVersion().isR4B() ? null : prefix+"uml.html#abstract", false);
     }
     if (rootStatus != null)
       gc.addStyledText("Standards Status = "+rootStatus.toDisplay(), rootStatus.getAbbrev(), "black", rootStatus.getColor(), prefix+"versions.html#std-process", true);


### PR DESCRIPTION
Previous PR left characters in TableGenerator that confused and disoriented JavaDoc. This replaces them with milder, more palatable characters.