### PR TITLE
Bump core version + fix isR4B breakages

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-fhirCoreVersion = 5.6.51
+fhirCoreVersion = 5.6.53
 apachePoiVersion = 4.1.1
 ## Leave the subsequent line blank for additional properties appended by azure builds

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/DictHTMLGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/DictHTMLGenerator.java
@@ -67,6 +67,7 @@ import org.hl7.fhir.tools.publisher.PageProcessor;
 import org.hl7.fhir.utilities.CommaSeparatedStringBuilder;
 import org.hl7.fhir.utilities.StandardsStatus;
 import org.hl7.fhir.utilities.Utilities;
+import org.hl7.fhir.utilities.VersionUtilities;
 
 public class DictHTMLGenerator  extends OutputStreamWriter {
 
@@ -547,7 +548,7 @@ public class DictHTMLGenerator  extends OutputStreamWriter {
 	}
 	
 	private boolean isR5() {
-    return !page.getVersion().isR4B();
+    return !VersionUtilities.isR4BVer(page.getVersion().toCode());
   }
 
   private String patternAnalysis(ElementDefn e) {

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/ProfileGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/ProfileGenerator.java
@@ -195,7 +195,7 @@ public class ProfileGenerator {
     if (uml != null) {
       if (!uml.hasPackage("core")) {
         this.uml = uml.getPackage("core");
-        if (version.isR4B()) {
+        if (VersionUtilities.isR4BVer(version.toCode())) {
           this.uml.getTypes().put("Type", new UMLClass("Type", UMLClassType.Class));
           this.uml.getTypes().put("PrimitiveType", new UMLClass("PrimitiveType", UMLClassType.Class));
         } else {

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/SvgGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/SvgGenerator.java
@@ -25,6 +25,7 @@ import org.hl7.fhir.tools.publisher.PageProcessor;
 import org.hl7.fhir.utilities.IniFile;
 import org.hl7.fhir.utilities.StandardsStatus;
 import org.hl7.fhir.utilities.Utilities;
+import org.hl7.fhir.utilities.VersionUtilities;
 import org.hl7.fhir.utilities.xml.XMLWriter;
 
 public class SvgGenerator extends BaseGenerator {
@@ -751,7 +752,7 @@ public class SvgGenerator extends BaseGenerator {
           if (cd instanceof DefinedStringPattern) {
             links.add(new Link(classes.get(fakes.get(((DefinedStringPattern) cd).getBase())), drawClass(xml, fake, false, null, true, null, cd, StandardsStatus.NORMATIVE), LinkType.SPECIALIZATION, null, null, PointKind.unknown, null, null));        
           } else {
-            ClassItem parent = classes.get(definitions.getElementDefn(version.isR4B() ? "Element" : "PrimitiveType"));
+            ClassItem parent = classes.get(definitions.getElementDefn(VersionUtilities.isR4BVer(version.toCode()) ? "Element" : "PrimitiveType"));
             if (parent == null) {
               drawClass(xml, fake, false, null, true, null, cd, StandardsStatus.NORMATIVE); 
             } else {
@@ -761,7 +762,7 @@ public class SvgGenerator extends BaseGenerator {
         } else if ("xhtml".equals(cn)) {
           DefinedCode cd = new DefinedCode("xhtml", "XHTML for resource narrative", null);
           ElementDefn fake = fakes.get(cn);
-          ClassItem parent = classes.get(definitions.getElementDefn(version.isR4B() ? "Element" :"DataType"));
+          ClassItem parent = classes.get(definitions.getElementDefn(VersionUtilities.isR4BVer(version.toCode()) ? "Element" :"DataType"));
           if (parent == null) {
             drawClass(xml, fake, false, null, true, null, cd, StandardsStatus.NORMATIVE);
           } else {
@@ -1011,7 +1012,7 @@ public class SvgGenerator extends BaseGenerator {
           allPrimitive = false;
         }
       }
-      if (version.isR4B()) {
+      if (VersionUtilities.isR4BVer(version.toCode())) {
         return "Element";
       } if (allPrimitive) {
         return "PrimitiveType";

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/TableGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/TableGenerator.java
@@ -16,6 +16,7 @@ import org.hl7.fhir.r5.model.ValueSet;
 import org.hl7.fhir.tools.publisher.PageProcessor;
 import org.hl7.fhir.utilities.StandardsStatus;
 import org.hl7.fhir.utilities.Utilities;
+import org.hl7.fhir.utilities.VersionUtilities;
 import org.hl7.fhir.utilities.xhtml.HierarchicalTableGenerator;
 import org.hl7.fhir.utilities.xhtml.HierarchicalTableGenerator.Cell;
 import org.hl7.fhir.utilities.xhtml.HierarchicalTableGenerator.Row;
@@ -68,9 +69,9 @@ public class TableGenerator extends BaseGenerator {
       gc.addStyledText("This element has or is affected by some invariants", "I", null, null, prefix+"conformance-rules.html#constraints", false);
     }
     if (isInterface) {
-      gc.addStyledText("This is an interface resource", "«I»", null, null, page.getVersion().isR4B() ? null : prefix+"uml.html#interface", false);
+      gc.addStyledText("This is an interface resource", "«I»", null, null, VersionUtilities.isR4BVer(page.getVersion().toCode()) ? null : prefix+"uml.html#interface", false);
     } else if (isAbstract) {
-      gc.addStyledText("This is an abstract type", "«A»", null, null, page.getVersion().isR4B() ? null : prefix+"uml.html#abstract", false);
+      gc.addStyledText("This is an abstract type", "«A»", null, null, VersionUtilities.isR4BVer(page.getVersion().toCode()) ? null : prefix+"uml.html#abstract", false);
     }
     if (rootStatus != null)
       gc.addStyledText("Standards Status = "+rootStatus.toDisplay(), rootStatus.getAbbrev(), "black", rootStatus.getColor(), prefix+"versions.html#std-process", true);
@@ -98,7 +99,7 @@ public class TableGenerator extends BaseGenerator {
         else if (e.getName().equals("Type"))
           row.getCells().add(gen.new Cell(null, null, "", null, null)); 
         else if (e.getName().equals("Element")) {
-          if (version.isR4B()) {
+          if (VersionUtilities.isR4BVer(page.getVersion().toCode())) {
             row.getCells().add(gen.new Cell(null, prefix+definitions.getElementLink(), "Element", null, null));
           } else {
             row.getCells().add(gen.new Cell(null, prefix+definitions.getBaseLink(), "Base", null, null));            

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/json/JsonLDDefinitionsGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/json/JsonLDDefinitionsGenerator.java
@@ -16,6 +16,7 @@ import org.hl7.fhir.utilities.TextFile;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
+import org.hl7.fhir.utilities.VersionUtilities;
 
 public class JsonLDDefinitionsGenerator {
 
@@ -39,7 +40,7 @@ public class JsonLDDefinitionsGenerator {
 	  addProperty(context, "value", "fhir:value", "xsd:string");
     addProperty(context, "decimal", "fhir:value", "xsd:decimal");
     addProperty(context, "integer", "fhir:value", "xsd:integer");
-    if (!version.isR4B()) {
+    if (!VersionUtilities.isR4BVer(version.toCode())) {
       addProperty(context, "integer64", "fhir:value", "xsd:string");
     }
     addProperty(context, "boolean", "fhir:value", "xsd:boolean");

--- a/src/main/java/org/hl7/fhir/definitions/model/Definitions.java
+++ b/src/main/java/org/hl7/fhir/definitions/model/Definitions.java
@@ -54,6 +54,7 @@ import org.hl7.fhir.r5.model.ValueSet;
 import org.hl7.fhir.r5.model.Enumerations.FHIRVersion;
 import org.hl7.fhir.r5.utils.FHIRPathEngine;
 import org.hl7.fhir.utilities.Utilities;
+import org.hl7.fhir.utilities.VersionUtilities;
 
 /**
  * This class is the root to all the definitions in FHIR. There are the
@@ -866,7 +867,7 @@ public class Definitions {
   }
 
   public String getElementLink() {
-    if (version.isR4B()) {
+    if (VersionUtilities.isR4BVer(version.toCode())) {
       return "element.html";
     } else {
       return "types.html#Element";
@@ -874,7 +875,7 @@ public class Definitions {
   }
 
   public String getBackboneLink() {
-    if (version.isR4B()) {
+    if (VersionUtilities.isR4BVer(version.toCode())) {
       return "backboneelement.html";
     } else {
       return "types.html#BackBoneElement";
@@ -882,7 +883,7 @@ public class Definitions {
   }
 
   public String getBaseLink() {
-    if (version.isR4B()) {
+    if (VersionUtilities.isR4BVer(version.toCode())) {
       return "element.html";
     } else {
       return "types.html#Base";
@@ -890,7 +891,7 @@ public class Definitions {
   }
 
   public String getElementExtrasLink() {
-    if (version.isR4B()) {
+    if (VersionUtilities.isR4BVer(version.toCode())) {
       return "element-extras.html";
     } else {
       return "types-extras.html#Element";

--- a/src/main/java/org/hl7/fhir/tools/converters/DSTU3ValidationConvertor.java
+++ b/src/main/java/org/hl7/fhir/tools/converters/DSTU3ValidationConvertor.java
@@ -11,6 +11,7 @@ import org.hl7.fhir.dstu3.formats.IParser.OutputStyle;
 import org.hl7.fhir.r5.formats.XmlParser;
 import org.hl7.fhir.r5.model.Bundle;
 import org.hl7.fhir.r5.model.Enumerations.FHIRVersion;
+import org.hl7.fhir.utilities.VersionUtilities;
 
 public class DSTU3ValidationConvertor {
 
@@ -25,7 +26,7 @@ public class DSTU3ValidationConvertor {
     
     try {
       org.hl7.fhir.dstu3.model.Bundle target = null;      
-      if (version.isR4B()) {
+      if (VersionUtilities.isR4BVer(version.toCode())) {
         org.hl7.fhir.r4.model.Bundle source = (org.hl7.fhir.r4.model.Bundle) new org.hl7.fhir.r4.formats.XmlParser().parse(new FileInputStream(bundleSource));
         target = (org.hl7.fhir.dstu3.model.Bundle) VersionConvertorFactory_30_40.convertResource(source);
         
@@ -45,7 +46,7 @@ public class DSTU3ValidationConvertor {
     
     try {
       org.hl7.fhir.dstu3.model.Bundle target = null;      
-      if (version.isR4B()) {
+      if (VersionUtilities.isR4BVer(version.toCode())) {
         org.hl7.fhir.r4.model.Bundle source = (org.hl7.fhir.r4.model.Bundle) new org.hl7.fhir.r4.formats.XmlParser().parse(new FileInputStream(bundleSource));
         target = (org.hl7.fhir.dstu3.model.Bundle) VersionConvertorFactory_30_40.convertResource(source);
         

--- a/src/main/java/org/hl7/fhir/tools/publisher/PageProcessor.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/PageProcessor.java
@@ -191,16 +191,8 @@ import org.hl7.fhir.r5.utils.TypesUtilities;
 import org.hl7.fhir.r5.utils.TypesUtilities.TypeClassification;
 import org.hl7.fhir.r5.utils.TypesUtilities.WildcardInformation;
 import org.hl7.fhir.tools.converters.MarkDownPreProcessor;
-import org.hl7.fhir.utilities.CSFile;
-import org.hl7.fhir.utilities.CSFileInputStream;
-import org.hl7.fhir.utilities.CommaSeparatedStringBuilder;
-import org.hl7.fhir.utilities.IniFile;
-import org.hl7.fhir.utilities.Logger;
-import org.hl7.fhir.utilities.MarkDownProcessor;
+import org.hl7.fhir.utilities.*;
 import org.hl7.fhir.utilities.MarkDownProcessor.Dialect;
-import org.hl7.fhir.utilities.StandardsStatus;
-import org.hl7.fhir.utilities.TextFile;
-import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
 import org.hl7.fhir.utilities.npm.NpmPackage;
 import org.hl7.fhir.utilities.npm.ToolsVersion;
@@ -9167,7 +9159,7 @@ public class PageProcessor implements Logger, ProfileKnowledgeProvider, IReferen
     workerContext.setVersion(version.toCode());
     htmlchecker.setVersion(version);
     uml.setVersion(version.toCode());
-    if (version.isR4B() && baseURL.equals("http://build.fhir.org/")) {
+    if (VersionUtilities.isR4BVer(version.toCode()) && baseURL.equals("http://build.fhir.org/")) {
       setBaseURL("http://build.fhir.org/branches/R4B/");
     }
   }
@@ -10878,7 +10870,7 @@ private int countContains(List<ValueSetExpansionContainsComponent> list) {
   }
 
   private String pidRoot() {
-    return version.isR4B() ? "hl7.fhir.r4b" : "hl7.fhir.r5";
+    return VersionUtilities.isR4BVer(version.toCode()) ? "hl7.fhir.r4b" : "hl7.fhir.r5";
   }
 
 

--- a/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
@@ -242,18 +242,8 @@ import org.hl7.fhir.tools.converters.CDAGenerator;
 import org.hl7.fhir.tools.converters.DSTU3ValidationConvertor;
 import org.hl7.fhir.tools.converters.SpecNPMPackageGenerator;
 import org.hl7.fhir.tools.publisher.ExampleInspector.EValidationFailed;
-import org.hl7.fhir.utilities.CSFile;
-import org.hl7.fhir.utilities.CSFileInputStream;
-import org.hl7.fhir.utilities.CloseProtectedZipInputStream;
-import org.hl7.fhir.utilities.CommaSeparatedStringBuilder;
-import org.hl7.fhir.utilities.IniFile;
+import org.hl7.fhir.utilities.*;
 import org.hl7.fhir.utilities.Logger.LogMessageType;
-import org.hl7.fhir.utilities.NDJsonWriter;
-import org.hl7.fhir.utilities.SIDUtilities;
-import org.hl7.fhir.utilities.TextFile;
-import org.hl7.fhir.utilities.Utilities;
-import org.hl7.fhir.utilities.XsltUtilities;
-import org.hl7.fhir.utilities.ZipGenerator;
 import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
 import org.hl7.fhir.utilities.npm.PackageGenerator.PackageType;
 import org.hl7.fhir.utilities.npm.ToolsVersion;
@@ -1564,7 +1554,7 @@ public class Publisher implements URIResolver, SectionNumberer {
   }
 
   void serializeResource(Resource r, String baseFileName, String description, String pageType, String crumbTitle, WorkGroup wg, boolean showCanonical, boolean showTtl, boolean canonicalTtlOnly) throws Exception {
-    if (page.getVersion().isR4B()) {
+    if (VersionUtilities.isR4BVer(page.getVersion().toCode())) {
       org.hl7.fhir.r4.model.Resource r2 = VersionConvertorFactory_40_50.convertResource(r);
       org.hl7.fhir.r4.formats.IParser xml = new org.hl7.fhir.r4.formats.XmlParser().setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.PRETTY);
       xml.compose(new FileOutputStream(Utilities.path(page.getFolders().dstDir, baseFileName + ".xml")), r2);
@@ -2978,7 +2968,7 @@ public class Publisher implements URIResolver, SectionNumberer {
   }
 
   private String pidRoot() {
-    return page.getVersion().isR4B() ? "hl7.fhir.r4b" : "hl7.fhir.r5";
+    return VersionUtilities.isR4BVer(page.getVersion().toCode()) ? "hl7.fhir.r4b" : "hl7.fhir.r5";
   }
 
 
@@ -3760,7 +3750,7 @@ public class Publisher implements URIResolver, SectionNumberer {
 
   private String resource2Json(Resource r) throws Exception {
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-    if (page.getVersion().isR4B()) {
+    if (VersionUtilities.isR4BVer(page.getVersion().toCode())) {
       org.hl7.fhir.r4.formats.IParser json = new org.hl7.fhir.r4.formats.JsonParser().setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.PRETTY);
       json.setSuppressXhtml("Snipped for Brevity");
       json.compose(bytes, VersionConvertorFactory_40_50.convertResource(r));      
@@ -3775,7 +3765,7 @@ public class Publisher implements URIResolver, SectionNumberer {
 
   private String resource2Ttl(Resource r) throws Exception {
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-    if (page.getVersion().isR4B()) {
+    if (VersionUtilities.isR4BVer(page.getVersion().toCode())) {
       org.hl7.fhir.r4.formats.IParser rdf = new org.hl7.fhir.r4.formats.RdfParser().setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.PRETTY);
       rdf.setSuppressXhtml("Snipped for Brevity");
       rdf.compose(bytes, VersionConvertorFactory_40_50.convertResource(r));
@@ -4408,7 +4398,7 @@ public class Publisher implements URIResolver, SectionNumberer {
           wantSave = true;
         }
         if (wantSave) {
-          if (page.getVersion().isR4B()) {
+          if (VersionUtilities.isR4BVer(page.getVersion().toCode())) {
             org.hl7.fhir.r4.model.Resource r4 = new org.hl7.fhir.r4.formats.XmlParser().parse(new FileInputStream(file));
             new org.hl7.fhir.r4.formats.XmlParser().setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.PRETTY).compose(new FileOutputStream(file), r4);
           } else {
@@ -4498,7 +4488,7 @@ public class Publisher implements URIResolver, SectionNumberer {
         addToResourceFeed(vs, valueSetsFeed, file.getName());
         page.getDefinitions().getValuesets().see(vs, page.packageInfo());
       } catch (Exception ex) {
-        if (page.getVersion().isR4B()) {
+        if (VersionUtilities.isR4BVer(page.getVersion().toCode())) {
           System.out.println("Value set "+file.getAbsolutePath()+" couldn't be parsed - ignoring! msg = "+ex.getMessage());
         } else {
           throw new FHIRException("Unable to parse "+file.getAbsolutePath()+": "+ex.getMessage(), ex);             
@@ -4560,7 +4550,7 @@ public class Publisher implements URIResolver, SectionNumberer {
     } catch (Exception ex) {
       // If it's not a resource, that's fine
     }
-    if (r != null && page.getVersion().isR4B()) {
+    if (r != null && VersionUtilities.isR4BVer(page.getVersion().toCode())) {
       org.hl7.fhir.r4.model.Resource r2 = VersionConvertorFactory_40_50.convertResource(r);
       org.hl7.fhir.r4.formats.IParser xml = new org.hl7.fhir.r4.formats.XmlParser().setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.PRETTY);
       xml.compose(new FileOutputStream(Utilities.path(page.getFolders().dstDir, prefix + n + ".xml")), r2);
@@ -4664,7 +4654,7 @@ public class Publisher implements URIResolver, SectionNumberer {
   }
 
   public Resource loadExample(CSFile file) throws IOException, FileNotFoundException {
-    if (page.getVersion().isR4B()) {
+    if (VersionUtilities.isR4BVer(page.getVersion().toCode())) {
       org.hl7.fhir.r4.model.Resource res = new org.hl7.fhir.r4.formats.XmlParser().parse(new FileInputStream(file));
       return VersionConvertorFactory_40_50.convertResource(res);
     } else {


### PR DESCRIPTION
isR4B method no longer exists.

See notes here; a change in VersionUtilities in core may also be necessary:

https://github.com/hapifhir/org.hl7.fhir.core/commit/392b0644332aed27a164c094697c4a15e8b00944#r79460808