### PR TITLE
Switch to toCode instead of toString for Enumerations.fhirVersions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "org.hl7.fhir"
-version = "1.0.14-SNAPSHOT"
+version = "1.0.13-SNAPSHOT"
 
 java {
     withJavadocJar()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "org.hl7.fhir"
-version = "1.0.13-SNAPSHOT"
+version = "1.0.14-SNAPSHOT"
 
 java {
     withJavadocJar()

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/ProfileGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/ProfileGenerator.java
@@ -1692,7 +1692,7 @@ public class ProfileGenerator {
             }
           } else if (t.isWildcardType()) {
             // this list is filled out manually because it may be running before the types referred to have been loaded
-            for (String n : TypesUtilities.wildcardTypes(version.toString())) 
+            for (String n : TypesUtilities.wildcardTypes(version.toCode()))
               expandedTypes.add(new TypeRef(n));
 
           } else if (!t.getName().startsWith("=")) {
@@ -2268,7 +2268,7 @@ public class ProfileGenerator {
           }
         }
       } else if (t.isWildcardType()) {
-        for (String n : TypesUtilities.wildcardTypes(version.toString())) 
+        for (String n : TypesUtilities.wildcardTypes(version.toCode()))
           dst.getType(n);
       } else {
         if (definitions != null && definitions.getConstraints().containsKey(t.getName())) {

--- a/src/main/java/org/hl7/fhir/definitions/parsers/SourceParser.java
+++ b/src/main/java/org/hl7/fhir/definitions/parsers/SourceParser.java
@@ -1139,7 +1139,7 @@ public class SourceParser {
   }
 
   private String loadCompositeType(String n, Map<String, org.hl7.fhir.definitions.model.TypeDefn> map, String fmm, boolean isAbstract) throws Exception {
-    TypeParser tp = new TypeParser(version.toString());
+    TypeParser tp = new TypeParser(version.toCode());
     List<TypeRef> ts = tp.parse(n, false, null, context, true);
     definitions.getKnownTypes().addAll(ts);
 
@@ -1396,7 +1396,7 @@ public class SourceParser {
 
     for (String n : ini.getPropertyNames("types"))
       if (ini.getStringProperty("types", n).equals("")) {
-        TypeRef t = new TypeParser(version.toString()).parse(n, false, null, context, true).get(0);
+        TypeRef t = new TypeParser(version.toCode()).parse(n, false, null, context, true).get(0);
         checkFile("type definition", dtDir, t.getName().toLowerCase() + ".xml", errors, "all");
       }
 


### PR DESCRIPTION
Enumerations.FHIRVersion used to have a toString() method that called toCode() for its return value.

This commit restores this behaviour by switching to toCode explicitly to avoid the underscore error produced in the current FHIR build, where ```TypesUtilities.wildcards()``` still expected the original underscore-less value:

```
Exception in thread "main" java.lang.Error: underscore
        at org.hl7.fhir.r5.utils.TypesUtilities.wildcards(TypesUtilities.java:101)
        at org.hl7.fhir.r5.utils.TypesUtilities.wildcardTypes(TypesUtilities.java:87)
        at org.hl7.fhir.definitions.generators.specification.ProfileGenerator.defineElement(ProfileGenerator.java:1695)
        at org.hl7.fhir.definitions.generators.specification.ProfileGenerator.defineElement(ProfileGenerator.java:1807)
        at org.hl7.fhir.definitions.generators.specification.ProfileGenerator.generate(ProfileGenerator.java:782)
        at org.hl7.fhir.definitions.parsers.SourceParser.genTypeProfile(SourceParser.java:1128)
        at org.hl7.fhir.definitions.parsers.SourceParser.loadCompositeType(SourceParser.java:1159)
        at org.hl7.fhir.definitions.parsers.SourceParser.parse(SourceParser.java:242)
        at org.hl7.fhir.tools.publisher.Publisher.execute(Publisher.java:671)
        at org.hl7.fhir.tools.publisher.Publisher.main(Publisher.java:482)
        ```