### PR TITLE
Patch: switch to toCode instead of toString for Enumerations.fhirVersions - Part 2

### DIFF
--- a/src/main/java/org/hl7/fhir/tools/converters/SpecNPMPackageGenerator.java
+++ b/src/main/java/org/hl7/fhir/tools/converters/SpecNPMPackageGenerator.java
@@ -78,7 +78,7 @@ public class SpecNPMPackageGenerator {
     Map<String, byte[]> files = loadZip(new FileInputStream(Utilities.path(folder, "igpack.zip")));
     FHIRVersion version = determineVersion(files);    
     
-    System.out.println(" .. Loading v"+version);
+    System.out.println(" .. Loading v"+version.toCode());
     SpecMapManager spm = new SpecMapManager(files.get("spec.internals"), version.toCode());    
     System.out.println(" .. Conformance Resources");
     List<ResourceEntry> reslist = makeResourceList(files, version.toCode());

--- a/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
@@ -3251,7 +3251,7 @@ public class Publisher implements URIResolver, SectionNumberer {
 
   private boolean checkMetaData(StructureDefinition sd) {
     check(tail(sd.getUrl()).equals(sd.getId()), sd, "id must equal tail of URL");
-    check(page.getVersion().equals(sd.getFhirVersion()), sd, "FhirVersion is wrong (should be "+page.getVersion()+", is "+sd.getFhirVersion()+")");
+    check(page.getVersion().toCode().equals(sd.getFhirVersion()), sd, "FhirVersion is wrong (should be "+page.getVersion().toCode()+", is "+sd.getFhirVersion().toCode()+")");
     switch (sd.getKind()) {
     case COMPLEXTYPE: return checkDataType(sd);
     case PRIMITIVETYPE: return checkDataType(sd);


### PR DESCRIPTION
Catch remaining toString instances from debugged run