### PR TITLE
Add CI_BRANCH_DIRECTORY for use with CI builds

### DIFF
--- a/main-branch-pipeline.yml
+++ b/main-branch-pipeline.yml
@@ -24,6 +24,8 @@ strategy:
 variables:
 - group: GPG_VARIABLE_GROUP
 - group: SONATYPE_VARIABLE_GROUP
+- name: CI_BRANCH_DIRECTORY
+  value: $[ replace(variables['System.PullRequest.SourceBranch'], '/', '_') ]
 
 steps:
 

--- a/main-branch-pipeline.yml
+++ b/main-branch-pipeline.yml
@@ -24,8 +24,6 @@ strategy:
 variables:
 - group: GPG_VARIABLE_GROUP
 - group: SONATYPE_VARIABLE_GROUP
-- name: CI_BRANCH_DIRECTORY
-  value: $[ replace(variables['System.PullRequest.SourceBranch'], '/', '_') ]
 
 steps:
 

--- a/src/main/java/org/hl7/fhir/tools/publisher/FolderManager.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/FolderManager.java
@@ -93,6 +93,12 @@ public class FolderManager {
   public String ghRepo;
   public String ghBranch;
 
+  /**
+   * A target directory name for use in CI builds. This is set by the CI
+   * pipeline, and is normally derived from the github branch (special
+   * characters removed, etc)
+   */
+  public String ciDir;
   
   public String implDir(String name) {
     return rootDir+"implementations"+sl+name+sl;
@@ -116,6 +122,10 @@ public class FolderManager {
             ",\n tmpDir='" + tmpDir + '\'' +
             ",\n javaDir='" + javaDir + '\'' +
             ",\n archiveDir='" + archiveDir + '\'' +
+            ",\n ghOrg='" + ghOrg + '\'' +
+            ",\n ghRepo='" + ghRepo + '\'' +
+            ",\n ghBranch='" + ghBranch + '\'' +
+            ",\n ciDir='" + ciDir + '\'' +
             '}';
   }
 }

--- a/src/main/java/org/hl7/fhir/tools/publisher/PageProcessor.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/PageProcessor.java
@@ -9334,7 +9334,7 @@ public class PageProcessor implements Logger, ProfileKnowledgeProvider, IReferen
       client = null;
     }
 
-    tcm = new TerminologyCacheManager(client.getServerVersion(), folders.rootDir, folders.ghOrg, folders.ghRepo, folders.ghBranch);
+    tcm = new TerminologyCacheManager(client.getServerVersion(), folders.rootDir, folders.ghOrg, folders.ghRepo, folders.ciDir);
     log("Load Terminology Cache from "+tcm.getFolder(), LogMessageType.Process);
     tcm.initialize();
 

--- a/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
@@ -512,10 +512,12 @@ public class Publisher implements URIResolver, SectionNumberer {
     // this is how we find out about the git info on the CI-build
     String srcRepo = System.getenv("SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI");
     String srcBranch = System.getenv("SYSTEM_PULLREQUEST_SOURCEBRANCH");
-    if (srcRepo != null && srcBranch != null) {
+    String ciBranch = System.getenv("CI_BRANCH_DIRECTORY");
+    if (srcRepo != null && srcBranch != null && ciBranch != null) {
       if (srcRepo.contains("github.com")) {
         processGitHubUrl(srcRepo);
         page.getFolders().ghBranch = srcBranch;
+        page.getFolders().ciDir = ciBranch;
         System.out.println("This is a GitHub Repository: https://github.com/"+page.getFolders().ghOrg+"/"+page.getFolders().ghRepo+"/"+page.getFolders().ghBranch);
         return;
       }
@@ -531,6 +533,8 @@ public class Publisher implements URIResolver, SectionNumberer {
             List<Ref> branches = git.branchList().call();
             for (Ref ref : branches) {
               page.getFolders().ghBranch = ref.getName().substring(ref.getName().lastIndexOf("/") + 1, ref.getName().length());
+              // We won't have an explicit CI dir, so set this to ghBranch
+              page.getFolders().ciDir = page.getFolders().ghBranch;
               System.out.println("This is a GitHub Repository: https://github.com/"+page.getFolders().ghOrg+"/"+page.getFolders().ghRepo+"/"+page.getFolders().ghBranch);
               return;
             }          


### PR DESCRIPTION
This adds a CI_BRANCH_DIRECTORY derived from the GitHub branch name, for use in creating directories like the txCache.