### PR TITLE
Add warning if file encoding isn't UTF-8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-fhirCoreVersion = 5.6.62
+fhirCoreVersion = 5.6.68
 apachePoiVersion = 4.1.1
 ## Leave the subsequent line blank for additional properties appended by azure builds

--- a/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
@@ -453,6 +453,8 @@ public class Publisher implements URIResolver, SectionNumberer {
   private IniFile apiKeyFile;
 
   public static void main(String[] args) throws Exception {
+    org.hl7.fhir.utilities.FileFormat.checkCharsetAndWarnIfNotUTF8(System.out);
+
     Publisher pub = new Publisher();
     pub.page = new PageProcessor(KindlingConstants.DEF_TS_SERVER);
     pub.isGenerate = !(args.length > 1 && hasParam(args, "-nogen"));


### PR DESCRIPTION
This PR requires that org.hl7.fhir.core 5.6.68 is released and will fail all checks until it is.