### PR TITLE
Switch to Java 11

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -36,7 +36,7 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
 	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,8 +93,8 @@ dependencies {
     implementation("org.apache.jena", "jena-iri", "3.1.0")
     implementation("org.apache.jena", "jena-base", "3.1.0")
     implementation("org.apache.jena", "jena-shaded-guava", "3.1.0")
-    implementation("xerces", "xercesImpl", "2.11.0")
-    implementation("xml-apis", "xml-apis", "1.4.01")
+    implementation("xerces", "xercesImpl", "2.12.2")
+    //implementation("xml-apis", "xml-apis", "1.4.01")
     implementation("com.fasterxml.jackson.core", "jackson-core", "2.5.2")
     implementation("com.fasterxml.jackson.core", "jackson-databind", "2.5.2")
     implementation("com.fasterxml.jackson.core", "jackson-annotations", "2.5.2")
@@ -141,6 +141,10 @@ dependencies {
     implementation("org.jetbrains.kotlin", "kotlin-stdlib", "1.4.21")
 
     testImplementation("org.junit.jupiter","junit-jupiter","5.8.2")
+
+    configurations.implementation {
+        exclude(group = "xml-apis")
+    }
 }
 
 configurations {
@@ -150,8 +154,8 @@ configurations {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 publishing {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This is a second attempt to Switch to Java 11.

This differs from the previous because it takes into account loading into Eclipse, which doesn't correctly manage xml-apis compared to ./gradlew 