### PR TITLE
Use build server instead of file based IRI

### DIFF
--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
@@ -31,6 +31,7 @@ import org.hl7.fhir.rdf.FHIRResourceFactory;
 import org.hl7.fhir.rdf.RDFNamespace;
 import org.hl7.fhir.rdf.RDFTypeMap;
 import org.hl7.fhir.tools.publisher.BuildWorkerContext;
+import org.hl7.fhir.tools.publisher.PageProcessor;
 import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.validation.ValidationMessage;
 
@@ -111,14 +112,19 @@ public class FhirTurtleGenerator {
         commit(true);
     }
 
-    /**
-     * Emit an ontology definition for the file
-     */
+   /**
+    * Emit an ontology definition for the file
+    */
     private void genOntologyDefinition() {
         fact.fhir_ontology("fhir.ttl", "FHIR Model Ontology")
                 .addDataProperty(RDFS.comment, "Formal model of FHIR Clinical Resources")
-                .addObjectProperty(OWL2.versionIRI, ResourceFactory.createResource(host+"fhir.ttl"))
+                .addObjectProperty(OWL2.versionIRI, ResourceFactory.createResource(getOntologyVersionIRI() +"fhir.ttl"))
                 .addObjectProperty(OWL2.imports, ResourceFactory.createResource("http://hl7.org/fhir/w5.ttl"));
+    }
+
+    private String getOntologyVersionIRI() {
+        return host.startsWith("file:") ?
+                PageProcessor.CI_LOCATION : host;
     }
 
     /**

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/W5TurtleGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/W5TurtleGenerator.java
@@ -22,6 +22,7 @@ import org.hl7.fhir.r5.model.CodeSystem;
 import org.hl7.fhir.r5.model.ValueSet;
 import org.hl7.fhir.rdf.RDFNamespace;
 import org.hl7.fhir.tools.publisher.BuildWorkerContext;
+import org.hl7.fhir.tools.publisher.PageProcessor;
 import org.hl7.fhir.utilities.validation.ValidationMessage;
 
 /**
@@ -61,7 +62,7 @@ public class W5TurtleGenerator {
         w5.addProperty(RDFS.label, "W5 Categorization");
         w5.addProperty(RDFS.comment, "FHIR W5 categorization is a preliminary classification of the fhir property");
         w5.addVersionInfo("FHIR W5 categorization (Preliminary)");
-        w5.addProperty(OWL2.versionIRI, host+"w5.ttl");
+        w5.addProperty(OWL2.versionIRI, getOntologyVersionIRI()+"w5.ttl");
 
         // The only way to differentiate predicates from classes is the existence of subclasses -- if something
         // has subclasses or is a subclass then it is a class.  Otherwise it is a predicate...
@@ -109,6 +110,11 @@ public class W5TurtleGenerator {
         commit(model, true);
     }
 
+
+    private String getOntologyVersionIRI() {
+        return host.startsWith("file:") ?
+                PageProcessor.CI_LOCATION : host;
+    }
     public void commit(OntModel model, boolean header) throws Exception {
         RDFDataMgr.write(destination, model, RDFFormat.TURTLE_PRETTY);
         destination.flush();


### PR DESCRIPTION
Fixes an issue regarding RDF generation using Windows file paths, where backslashes are treated as special characters.

This builds FHIR correctly in Mac, and ~~passes the previous failure point in Windows, but hasn't been confirmed for a full Windows build~~ on Windows, as commented by @rettema below.