### PR TITLE
R5 FHIR RDF ontology updates

### DIFF
--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
@@ -329,6 +329,7 @@ public class FhirTurtleGenerator {
             baseFR.addObjectProperty(modifierExtensionClassProperty, modRes);
 
     }
+
     /**
      * Generates corresponding ontology for Modifier Extensions of fhir:OriginalProperty as fhir:_OriginalProperty
      */
@@ -344,13 +345,6 @@ public class FhirTurtleGenerator {
         baseFR.addObjectProperty(extProp, modRes);
     }
 
-
-    public String shortenName(String qualifiedName) {
-        if(qualifiedName.contains(".")) {
-            return qualifiedName.substring(qualifiedName.lastIndexOf(".") + 1);
-        }
-        return qualifiedName;
-    }
 
     /**
      * Iterate over the Element Definitions in baseResource generating restrictions and properties
@@ -486,5 +480,13 @@ public class FhirTurtleGenerator {
         return definitions.hasPrimitiveType(name)
                 || (name.endsWith("Type")
                 && definitions.getPrimitives().containsKey(name.substring(0, name.length()-4)));
+    }
+
+    // used for shortening property names
+    private static String shortenName(String qualifiedName) {
+        if(qualifiedName.contains(".")) {
+            return qualifiedName.substring(qualifiedName.lastIndexOf(".") + 1);
+        }
+        return qualifiedName;
     }
 }

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
@@ -309,7 +309,9 @@ public class FhirTurtleGenerator {
         processTypes(resourceName, rdRes, resourceType, resourceName, true);
         if(!Utilities.noString(resourceType.getW5()))
             rdRes.addObjectProperty(RDFS.subClassOf, RDFNamespace.W5.resourceRef(resourceType.getW5()));
-        if(definitions.getResources().containsKey(resourceName)  && classHasModifierExtensions.contains(resource.getLocalName())) { //Bundle, Binary, Parameters, DomainResource should not get modifier extensions here since they are under fhir:Resource instead of fhir:DomainResource
+        if(definitions.getResources().containsKey(resourceName)  && classHasModifierExtensions.contains(resource.getLocalName())) { 
+            //Bundle, Binary, Parameters, DomainResource should be excluded from this clause and not get modifier extensions here 
+            // since they are under fhir:Resource instead of fhir:DomainResource
             genModifierExtensions(resourceName, rdRes, resource.getLocalName());
         }
     }
@@ -333,15 +335,15 @@ public class FhirTurtleGenerator {
     /**
      * Generates corresponding ontology for Modifier Extensions of fhir:OriginalProperty as fhir:_OriginalProperty
      */
-    private void genPropertyModifierExtensions(String baseName, FHIRResource baseFR, String label) throws Exception {
+    private void genPropertyModifierExtensions(String baseName, FHIRResource baseFR, String qualifiedPredicateName) throws Exception {
         if(baseName.matches("modifierExtension")) return; //skip the special case of fhir:modifierExtension
 
         // could change to instantiate only once
         FHIRResource hasExt = fact.fhir_resource("modifierExtensionProperty", OWL2.AnnotationProperty,"modifierExtensionProperty").addDataProperty(RDFS.comment, "has modifier extension property");
-        Property extProp = ResourceFactory.createProperty(hasExt.resource.toString());  // maybe make this a singleton instead
+        Property extProp = ResourceFactory.createProperty(hasExt.resource.toString());  
 
         FHIRResource modRes = fact.fhir_objectProperty("_" + baseName);
-        modRes.addDataProperty(RDFS.comment, "(Modified) " + label);
+        modRes.addDataProperty(RDFS.comment, "(Modified) " + qualifiedPredicateName);
         baseFR.addObjectProperty(extProp, modRes);
     }
 

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
@@ -250,7 +250,7 @@ public class FhirTurtleGenerator {
                 dspRes.restriction(fact.fhir_restriction(v,
                         fact.fhir_datatype_restriction(dspTypeRes == XSD.xstring ? XSD.normalizedString : dspTypeRes, facets)));
             } else
-                dspRes.restriction(fact.fhir_restriction(value, dspTypeRes));
+                dspRes.restriction(fact.fhir_restriction(v, dspTypeRes));
         }
     }
 

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
@@ -59,7 +59,7 @@ public class FhirTurtleGenerator {
                 .addTitle("Terminal data value")
                 .resource;
         this.v = fact.fhir_resource("v", OWL2.DatatypeProperty, "fhir:v")
-                .addTitle("Terminal data value for primitive fhir datatypes that can be represented as a RDF literal")
+                .addTitle("Terminal data value for primitive FHIR datatypes that can be represented as a RDF literal")
                 .resource;
     }
 
@@ -335,7 +335,7 @@ public class FhirTurtleGenerator {
     /**
      * Generates corresponding ontology for Modifier Extensions of fhir:OriginalProperty as fhir:_OriginalProperty
      */
-    private void genPropertyModifierExtensions(String baseName, FHIRResource baseFR, String qualifiedPredicateName) throws Exception {
+    private void genPropertyModifierExtensions(String baseName, FHIRResource baseFR, String label) throws Exception {
         if(baseName.matches("modifierExtension")) return; //skip the special case of fhir:modifierExtension
 
         // could change to instantiate only once
@@ -343,7 +343,7 @@ public class FhirTurtleGenerator {
         Property extProp = ResourceFactory.createProperty(hasExt.resource.toString());  
 
         FHIRResource modRes = fact.fhir_objectProperty("_" + baseName);
-        modRes.addDataProperty(RDFS.comment, "(Modified) " + qualifiedPredicateName);
+        modRes.addDataProperty(RDFS.comment, "(Modified) " + label);
         baseFR.addObjectProperty(extProp, modRes);
     }
 

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
@@ -157,11 +157,11 @@ public class FhirTurtleGenerator {
 
 
         // Any element can have an index to assign order in a list
-        FHIRResource index = fact.fhir_dataProperty("index")
-                .addTitle("Ordering value for list")
-                .domain(Element)
-                .range(XSD.nonNegativeInteger);
-        Element.restriction(fact.fhir_cardinality_restriction(index.resource, XSD.nonNegativeInteger, 0, 1));
+//        FHIRResource index = fact.fhir_dataProperty("index")
+//                .addTitle("Ordering value for list")
+//                .domain(Element)
+//                .range(XSD.nonNegativeInteger);
+//        Element.restriction(fact.fhir_cardinality_restriction(index.resource, XSD.nonNegativeInteger, 0, 1));
 
         // References have an optional link
         FHIRResource link = fact.fhir_objectProperty("link").addTitle("URI of a reference");

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
@@ -55,7 +55,7 @@ public class FhirTurtleGenerator {
         this.issues = issues;
         this.host = host;
         this.fact = new FHIRResourceFactory();
-        this.value = fact.fhir_resource("value", OWL2.DatatypeProperty, "fhir:value")
+        this.value = fact.fhir_resource("value", OWL2.ObjectProperty, "fhir:value")
                 .addTitle("Terminal data value")
                 .resource;
         this.v = fact.fhir_resource("v", OWL2.DatatypeProperty, "fhir:v")

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
@@ -275,6 +275,9 @@ public class FhirTurtleGenerator {
                         .addTitle(td.getShortDefn())
                         .addDefinition(td.getDefinition());
         processTypes(typeName, typeRes, td, typeName, false);
+        if(classHasModifierExtensions.contains(parentName)) {
+            genModifierExtensions(typeName, typeRes, parentName);
+        }
     }
 
     /**

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
@@ -45,6 +45,7 @@ public class FhirTurtleGenerator {
     private List<ValidationMessage> issues;
     private FHIRResourceFactory fact;
     private Resource value;
+    private Resource v;
     private String host;
 
     // OWL doesn't recognize xsd:gYear, xsd:gYearMonth or xsd:date.  If true, map all three to xsd:datetime
@@ -61,6 +62,9 @@ public class FhirTurtleGenerator {
         this.fact = new FHIRResourceFactory();
         this.value = fact.fhir_resource("value", OWL2.DatatypeProperty, "fhir:value")
                 .addTitle("Terminal data value")
+                .resource;
+        this.v = fact.fhir_resource("v", OWL2.DatatypeProperty, "fhir:v")
+                .addTitle("Terminal data value for primitive fhir datatypes that can be represented as a RDF literal")
                 .resource;
     }
 
@@ -140,7 +144,7 @@ public class FhirTurtleGenerator {
         fact.fhir_class("Primitive")
                 .addTitle("Types with only a value")
                 .addDefinition("Types with only a value and no additional elements as children")
-                .restriction(fact.fhir_restriction(value, RDFS.Literal));
+                .restriction(fact.fhir_restriction(v, RDFS.Literal));
 
         // A resource can have an optional nodeRole
         FHIRResource treeRoot = fact.fhir_class("treeRoot")
@@ -166,7 +170,7 @@ public class FhirTurtleGenerator {
         // XHTML is an XML Literal -- but it isn't recognized by OWL so we use string
         FHIRResource NarrativeDiv = fact.fhir_dataProperty("Narrative.div");
         fact.fhir_class("xhtml", "Primitive")
-            .restriction(fact.fhir_cardinality_restriction(value, fact.fhir_datatype(XSD.xstring).resource, 1, 1));
+            .restriction(fact.fhir_cardinality_restriction(v, fact.fhir_datatype(XSD.xstring).resource, 1, 1));
     }
 
   /* ==============================================
@@ -185,7 +189,7 @@ public class FhirTurtleGenerator {
                 .addDefinition(pt.getDefinition());
         Resource rdfType = RDFTypeMap.xsd_type_for(ptName, owlTarget);
         if (rdfType != null)
-            ptRes.restriction(fact.fhir_cardinality_restriction(value, fact.fhir_datatype(rdfType).resource, 1, 1));
+            ptRes.restriction(fact.fhir_cardinality_restriction(v, fact.fhir_datatype(rdfType).resource, 1, 1));
     }
 
 
@@ -207,7 +211,7 @@ public class FhirTurtleGenerator {
             if (dspType.endsWith("+")) {
                 List<Resource> facets = new ArrayList<Resource>(1);
                 facets.add(fact.fhir_pattern(dsp.getRegex()));
-                dspRes.restriction(fact.fhir_restriction(value,
+                dspRes.restriction(fact.fhir_restriction(v,
                         fact.fhir_datatype_restriction(dspTypeRes == XSD.xstring ? XSD.normalizedString : dspTypeRes, facets)));
             } else
                 dspRes.restriction(fact.fhir_restriction(value, dspTypeRes));

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
@@ -315,7 +315,7 @@ public class FhirTurtleGenerator {
                         FHIRResource qualifiedPredicate = fact.fhir_objectProperty(qualifiedPredicateName, predicateResource.resource)
                                 .domain(baseResource)
                                 .range(targetRes);
-                        typeOpts.add(
+                        typeOpts.addAll(
                                 fact.fhir_cardinality_restriction(qualifiedPredicate.resource,
                                                                   targetRes,
                                                                   ed.getMinCardinality(),

--- a/src/main/java/org/hl7/fhir/definitions/model/ElementDefn.java
+++ b/src/main/java/org/hl7/fhir/definitions/model/ElementDefn.java
@@ -1091,7 +1091,7 @@ public class ElementDefn {
 	 */
 	public boolean enablesModifierExtensions() {
 		return this.getElements().stream().anyMatch(e ->
-				e.getName().matches("modifierExtension") && e.hasModifier());
+				e.getName().equals("modifierExtension") && e.hasModifier());
 	}
 
 	@Override

--- a/src/main/java/org/hl7/fhir/definitions/model/ElementDefn.java
+++ b/src/main/java/org/hl7/fhir/definitions/model/ElementDefn.java
@@ -1084,7 +1084,18 @@ public class ElementDefn {
       return rd.getNormativeVersion();
   }
 
-  @Override
+	/**
+	 * Method determines if a superclass enables the usage of modifierExtensions for its children
+	 * Currently these are for BackboneElement, BackboneType, and DomainResource
+	 * @return true if enables modifierExtensions
+	 */
+	public boolean enablesModifierExtensions() {
+		return this.getElements().stream().anyMatch(e ->
+				e.getName().matches("modifierExtension") && e.hasModifier());
+	}
+
+
+	@Override
   public String toString() {
     return path == null ? name : path;
   }

--- a/src/main/java/org/hl7/fhir/definitions/model/ElementDefn.java
+++ b/src/main/java/org/hl7/fhir/definitions/model/ElementDefn.java
@@ -1094,6 +1094,18 @@ public class ElementDefn {
 				e.getName().matches("modifierExtension") && e.hasModifier());
 	}
 
+	/**
+	 * Custom fix to change Definition to disable modifier extensions from appearing.
+	 * Probably should not be used for anything else...
+	 */
+	public void _disableModifierExtensions() {
+		for(ElementDefn e: this.elements) {
+			if(e.getName().matches("modifierExtension") && e.hasModifier()) {
+				e.setMaxCardinality(0);
+				e.setMinCardinality(0);
+			}
+		}
+	}
 
 	@Override
   public String toString() {

--- a/src/main/java/org/hl7/fhir/definitions/model/ElementDefn.java
+++ b/src/main/java/org/hl7/fhir/definitions/model/ElementDefn.java
@@ -1094,19 +1094,6 @@ public class ElementDefn {
 				e.getName().matches("modifierExtension") && e.hasModifier());
 	}
 
-	/**
-	 * Custom fix to change Definition to disable modifier extensions from appearing.
-	 * Probably should not be used for anything else...
-	 */
-	public void _disableModifierExtensions() {
-		for(ElementDefn e: this.elements) {
-			if(e.getName().matches("modifierExtension") && e.hasModifier()) {
-				e.setMaxCardinality(0);
-				e.setMinCardinality(0);
-			}
-		}
-	}
-
 	@Override
   public String toString() {
     return path == null ? name : path;

--- a/src/main/java/org/hl7/fhir/rdf/FHIRResource.java
+++ b/src/main/java/org/hl7/fhir/rdf/FHIRResource.java
@@ -1,6 +1,7 @@
 package org.hl7.fhir.rdf;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.rdf.model.Model;
@@ -98,6 +99,11 @@ public class FHIRResource {
 
     public FHIRResource restriction(Resource restriction) {
         return addObjectProperty(RDFS.subClassOf, restriction);
+    }
+
+    public List<FHIRResource> restriction(List<Resource> restrictions) {
+        return restrictions.stream().map(restriction -> addObjectProperty(RDFS.subClassOf, restriction)).collect(Collectors.toList());
+//        return addObjectProperty(RDFS.subClassOf, restriction);
     }
 
 }

--- a/src/main/java/org/hl7/fhir/rdf/FHIRResource.java
+++ b/src/main/java/org/hl7/fhir/rdf/FHIRResource.java
@@ -103,7 +103,6 @@ public class FHIRResource {
 
     public List<FHIRResource> restriction(List<Resource> restrictions) {
         return restrictions.stream().map(restriction -> addObjectProperty(RDFS.subClassOf, restriction)).collect(Collectors.toList());
-//        return addObjectProperty(RDFS.subClassOf, restriction);
     }
 
 }

--- a/src/main/java/org/hl7/fhir/rdf/FHIRResourceFactory.java
+++ b/src/main/java/org/hl7/fhir/rdf/FHIRResourceFactory.java
@@ -1,6 +1,7 @@
 package org.hl7.fhir.rdf;
 
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.jena.datatypes.xsd.XSDDatatype;
@@ -193,6 +194,18 @@ public class FHIRResourceFactory {
     }
 
     /**
+     * Create a new OWL Restriction to attach a property to via addObjectProperty or addDataProperty
+     *
+     * @param onProperty
+     * @return
+     */
+    public FHIRResource create_empty_owl_restriction(Resource onProperty) {  //TODO:add fix - changed name for clarity since I dont believe it is meant to be overloaded
+        return fhir_bnode()
+                .addType(OWL2.Restriction)
+                .addObjectProperty(OWL2.onProperty, onProperty);
+    }
+
+    /**
      * Create a new OWL restriction with the appropriate cardinality
      *
      * @param onProperty property to apply the restriction to
@@ -201,18 +214,20 @@ public class FHIRResourceFactory {
      * @param max        max cardinality
      * @return restriction resource
      */
-    public Resource fhir_cardinality_restriction(Resource onProperty, Resource from, int min, int max) {
-        FHIRResource rval = fhir_restriction(onProperty)
-                .addObjectProperty(min > 0 ? OWL2.someValuesFrom : OWL2.allValuesFrom, from);
+    public List<Resource> fhir_cardinality_restriction(Resource onProperty, Resource from, int min, int max) {
+        ArrayList<Resource> list = new ArrayList<>();
+
+        list.add(create_empty_owl_restriction(onProperty)
+                .addObjectProperty(min > 0 ? OWL2.someValuesFrom : OWL2.allValuesFrom, from).resource);
         if (min == max)
-            rval.addDataProperty(OWL2.cardinality, Integer.toBinaryString(min), XSDDatatype.XSDinteger);
+            list.add(create_empty_owl_restriction(onProperty).addDataProperty(OWL2.cardinality, Integer.toString(min), XSDDatatype.XSDinteger).resource);
         else {
-            if (min > 1)
-                rval.addDataProperty(OWL2.minCardinality, Integer.toBinaryString(min), XSDDatatype.XSDinteger);
+            if (min > 0)
+                list.add(create_empty_owl_restriction(onProperty).addDataProperty(OWL2.minCardinality, Integer.toString(min), XSDDatatype.XSDinteger).resource);
             if (max < Integer.MAX_VALUE)
-                rval.addDataProperty(OWL2.maxCardinality, Integer.toBinaryString(max), XSDDatatype.XSDinteger);
+                list.add(create_empty_owl_restriction(onProperty).addDataProperty(OWL2.maxCardinality, Integer.toString(max), XSDDatatype.XSDinteger).resource);  //TODO:add fix to normal String instead of Binary as a String (9 was previously  owl:maxCardinality  1001 ;) also changed to maxQualifiedCardinality
         }
-        return rval.resource;
+        return list;
     }
 
     /**
@@ -222,7 +237,7 @@ public class FHIRResourceFactory {
      * @param from
      * @return
      */
-    public Resource fhir_restriction(Resource onProperty, Resource from) {
+    public List<Resource> fhir_restriction(Resource onProperty, Resource from) {
         return fhir_cardinality_restriction(onProperty, from, 0, Integer.MAX_VALUE);
     }
 

--- a/src/main/java/org/hl7/fhir/rdf/FHIRResourceFactory.java
+++ b/src/main/java/org/hl7/fhir/rdf/FHIRResourceFactory.java
@@ -218,14 +218,13 @@ public class FHIRResourceFactory {
      */
     public List<Resource> fhir_cardinality_restriction(Resource onProperty, Resource from, int min, int max) {
         ArrayList<Resource> restrictions = new ArrayList<>();
-
-        restrictions.add(create_empty_owl_restriction(onProperty)
-                .addObjectProperty(min > 0 ? OWL2.someValuesFrom : OWL2.allValuesFrom, from).resource);
+        restrictions.add(create_empty_owl_restriction(onProperty).addObjectProperty(OWL2.allValuesFrom, from).resource);
         if (min == max)
             restrictions.add(create_empty_owl_restriction(onProperty).addDataProperty(OWL2.cardinality, Integer.toString(min), XSDDatatype.XSDinteger).resource);
         else {
             if (min > 0)
                 restrictions.add(create_empty_owl_restriction(onProperty).addDataProperty(OWL2.minCardinality, Integer.toString(min), XSDDatatype.XSDinteger).resource);
+                //restrictions.add(create_empty_owl_restriction(onProperty).addObjectProperty(OWL2.someValuesFrom, from).resource);  // use minCardinality instead
             if (max < Integer.MAX_VALUE)
                 restrictions.add(create_empty_owl_restriction(onProperty).addDataProperty(OWL2.maxCardinality, Integer.toString(max), XSDDatatype.XSDinteger).resource);  //TODO:add fix to normal String instead of Binary as a String (9 was previously  owl:maxCardinality  1001 ;) also changed to maxQualifiedCardinality
         }

--- a/src/main/java/org/hl7/fhir/rdf/FHIRResourceFactory.java
+++ b/src/main/java/org/hl7/fhir/rdf/FHIRResourceFactory.java
@@ -199,7 +199,7 @@ public class FHIRResourceFactory {
      * @param onProperty
      * @return
      */
-    public FHIRResource create_empty_owl_restriction(Resource onProperty) {  //TODO:add fix - changed name for clarity since I dont believe it is meant to be overloaded
+    public FHIRResource create_empty_owl_restriction(Resource onProperty) {  //changed name for clarity to avoid confusion
         return fhir_bnode()
                 .addType(OWL2.Restriction)
                 .addObjectProperty(OWL2.onProperty, onProperty);
@@ -225,7 +225,7 @@ public class FHIRResourceFactory {
             if (min > 0)
                 list.add(create_empty_owl_restriction(onProperty).addDataProperty(OWL2.minCardinality, Integer.toString(min), XSDDatatype.XSDinteger).resource);
             if (max < Integer.MAX_VALUE)
-                list.add(create_empty_owl_restriction(onProperty).addDataProperty(OWL2.maxCardinality, Integer.toString(max), XSDDatatype.XSDinteger).resource);  //TODO:add fix to normal String instead of Binary as a String (9 was previously  owl:maxCardinality  1001 ;) also changed to maxQualifiedCardinality
+                list.add(create_empty_owl_restriction(onProperty).addDataProperty(OWL2.maxCardinality, Integer.toString(max), XSDDatatype.XSDinteger).resource);
         }
         return list;
     }

--- a/src/main/java/org/hl7/fhir/rdf/FHIRResourceFactory.java
+++ b/src/main/java/org/hl7/fhir/rdf/FHIRResourceFactory.java
@@ -255,6 +255,17 @@ public class FHIRResourceFactory {
     }
 
     /**
+     * Returns a reference to an RDF List based on a supplied list of members
+     * @param members members to add to list
+     * @return Resource of List
+     */
+    public Resource fhir_list(List<Resource> members) {
+        return new FHIRResource(model, members).resource;
+    }
+
+
+
+    /**
      * Return a simple datatype restriction
      *
      * @param dataType data type to be restricted

--- a/src/main/java/org/hl7/fhir/rdf/RDFTypeMap.java
+++ b/src/main/java/org/hl7/fhir/rdf/RDFTypeMap.java
@@ -41,6 +41,7 @@ public class RDFTypeMap {
         ptMap.put("token", RDFNamespace.FHIR.resourceRef("token"));
         ptMap.put("nonNegativeInteger", XSD.nonNegativeInteger);
         ptMap.put("positiveInteger", XSD.positiveInteger);
+        ptMap.put("integer64", XSD.integer); //TODO: add this fix
 
         owlTypeMap.put(XSD.gYear, XSD.dateTime);
         owlTypeMap.put(XSD.gYearMonth, XSD.dateTime);

--- a/src/main/java/org/hl7/fhir/rdf/RDFTypeMap.java
+++ b/src/main/java/org/hl7/fhir/rdf/RDFTypeMap.java
@@ -1,6 +1,8 @@
 package org.hl7.fhir.rdf;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.jena.rdf.model.Resource;
@@ -13,6 +15,7 @@ public class RDFTypeMap {
      */
     static public final Map<String, Resource> ptMap = new HashMap<String, Resource>();
     static public final Map<Resource, Resource> owlTypeMap = new HashMap<Resource, Resource>();
+    static public final Map<String, List<Resource>> unionTypesMap = new HashMap<>();
 
     static {
         ptMap.put("base64Binary", XSD.base64Binary);
@@ -41,13 +44,18 @@ public class RDFTypeMap {
         ptMap.put("token", RDFNamespace.FHIR.resourceRef("token"));
         ptMap.put("nonNegativeInteger", XSD.nonNegativeInteger);
         ptMap.put("positiveInteger", XSD.positiveInteger);
-        ptMap.put("integer64", XSD.integer); //TODO: add this fix
+        ptMap.put("integer64", XSD.xlong);
 
         owlTypeMap.put(XSD.gYear, XSD.dateTime);
         owlTypeMap.put(XSD.gYearMonth, XSD.dateTime);
         owlTypeMap.put(XSD.date, XSD.dateTime);
         owlTypeMap.put(XSD.time, XSD.xstring);
         owlTypeMap.put(RDFNamespace.FHIR.resourceRef("xhtml"), XSD.xstring);
+
+        // Special datatypes that are a union of multiple types.
+        unionTypesMap.put("date", Arrays.asList(XSD.date, XSD.gYear, XSD.gYearMonth));
+        unionTypesMap.put("dateTime", Arrays.asList(XSD.dateTime, XSD.date , XSD.gYear, XSD.gYearMonth));
+        unionTypesMap.put("decimal", Arrays.asList(XSD.decimal, XSD.xdouble));
     }
 
     public static Resource xsd_type_for(String type, boolean owl_types_required) {


### PR DESCRIPTION
This PR is submitted to update the FHIR RDF Ontology generation (fhir.ttl) 

This PR is intended to address the following Jira issue: https://jira.hl7.org/browse/FHIR-39073

Summary of Changes:
- Change value[x] properties
- Shorten fully qualified property names
- fhir:v used in place of fhir:value in situations where the datatype in play can be represented as a RDF literal
- Update lists to use RDF Lists to replace fhir:index for ordering lists.
- Add ModiferExtension generation to the ontology generation.  
  -  Add code to generate ontology for definitions that are found to enable modifierExtensions (currently DomainResource, BackboneElement, BackboneType)
  - Classes that inherit from those that enable modifierExtensions will have entries as fhir:_XYZClass
  - Properties will similarly have corresponding entries such as fhir:_XYZProperty 
    - note: this is shortened property names from change listed above
- fhir:value a owl:DatatypeProperty (from owl:ObjectProperty)

- OWL Cardinality restriction fixes
  - Cardinality values have been switched from binary to standard (decimal) representation
  - minCardinality has been set to generate starting at 1 instead of 2
  - Adding separate blank nodes for each distinct OWL restriction to conform to OWL specifications.

- Added fhir:integer64 mapping to xsd:integer 

Some of validation for ontology will require fhir.shex be updated 
- see: https://jira.hl7.org/browse/FHIR-39074 