### PR TITLE
Replace all Utilities.uncheckedPath calls

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-fhirCoreVersion = 5.6.114-SNAPSHOT
+fhirCoreVersion = 5.6.115-SNAPSHOT
 apachePoiVersion = 4.1.1
 ## Leave the subsequent line blank for additional properties appended by azure builds

--- a/src/main/java/org/hl7/fhir/definitions/parsers/ResourceParser.java
+++ b/src/main/java/org/hl7/fhir/definitions/parsers/ResourceParser.java
@@ -85,12 +85,9 @@ import org.hl7.fhir.r5.terminologies.ValueSetUtilities;
 import org.hl7.fhir.r5.utils.BuildExtensions;
 import org.hl7.fhir.r5.utils.ToolingExtensions;
 import org.hl7.fhir.tools.publisher.BuildWorkerContext;
-import org.hl7.fhir.tools.publisher.KindlingUtilities;
-import org.hl7.fhir.utilities.CSFile;
-import org.hl7.fhir.utilities.CSFileInputStream;
-import org.hl7.fhir.utilities.StandardsStatus;
-import org.hl7.fhir.utilities.TextFile;
-import org.hl7.fhir.utilities.Utilities;
+import org.hl7.fhir.utilities.*;
+
+import javax.annotation.Nonnull;
 
 public class ResourceParser {
 
@@ -356,7 +353,7 @@ public class ResourceParser {
           indent = Integer.parseInt(filename.substring(0, filename.indexOf(" ")));
           filename = filename.substring(filename.indexOf(" ")).trim();
         }
-        String json = new JsonParser().setOutputStyle(OutputStyle.PRETTY).composeString(new XmlParser().parse(new FileInputStream(Utilities.uncheckedPath(folder, filename))));
+        String json = new JsonParser().setOutputStyle(OutputStyle.PRETTY).composeString(new XmlParser().parse(new FileInputStream(PathBuilder.getPathBuilder().withRequiredTarget(srcDir).buildPath(folder, filename))));
         process(content, indent, json);
       } else if (l.startsWith("$include ")) {
         int indent = 0;
@@ -365,14 +362,14 @@ public class ResourceParser {
           indent = Integer.parseInt(filename.substring(0, filename.indexOf(" ")));
           filename = filename.substring(filename.indexOf(" ")).trim();
         }
-        process(content, indent, TextFile.fileToString(Utilities.uncheckedPath(folder, filename)));
+        process(content, indent, TextFile.fileToString(PathBuilder.getPathBuilder().withRequiredTarget(srcDir).buildPath(folder, filename)));
       } else {
         content.append(Utilities.escapeXml(l));
         content.append("\r\n");
       }
     return new OperationExample(content.toString(), comment, resp);
   }
-  
+
   private void process(StringBuilder content, int indent, String s) {
     String pfx = Utilities.padLeft("",  ' ', indent);
     String[] lines = s.trim().split("\\r?\\n");

--- a/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
@@ -256,20 +256,8 @@ import org.hl7.fhir.tools.converters.CDAGenerator;
 import org.hl7.fhir.tools.converters.DSTU3ValidationConvertor;
 import org.hl7.fhir.tools.converters.SpecNPMPackageGenerator;
 import org.hl7.fhir.tools.publisher.ExampleInspector.EValidationFailed;
-import org.hl7.fhir.utilities.CSFile;
-import org.hl7.fhir.utilities.CSFileInputStream;
-import org.hl7.fhir.utilities.CloseProtectedZipInputStream;
-import org.hl7.fhir.utilities.CommaSeparatedStringBuilder;
-import org.hl7.fhir.utilities.IniFile;
+import org.hl7.fhir.utilities.*;
 import org.hl7.fhir.utilities.Logger.LogMessageType;
-import org.hl7.fhir.utilities.NDJsonWriter;
-import org.hl7.fhir.utilities.SIDUtilities;
-import org.hl7.fhir.utilities.StandardsStatus;
-import org.hl7.fhir.utilities.TextFile;
-import org.hl7.fhir.utilities.Utilities;
-import org.hl7.fhir.utilities.VersionUtilities;
-import org.hl7.fhir.utilities.XsltUtilities;
-import org.hl7.fhir.utilities.ZipGenerator;
 import org.hl7.fhir.utilities.i18n.I18nConstants;
 import org.hl7.fhir.utilities.json.JsonUtilities;
 import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
@@ -3344,7 +3332,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       expIg.setLicense(ImplementationGuide.SPDXLicense.CC01_0);
       expIg.setTitle("FHIR "+page.getVersion().getDisplay()+" package : Expansions");
       expIg.setDescription("Expansions for the "+page.getVersion().getDisplay()+" version of the FHIR standard");
-      NPMPackageGenerator npm = new NPMPackageGenerator(uncheckedPath(page.getFolders().dstDir, pidRoot() + ".expansions.tgz"), "http://hl7.org/fhir", "http://hl7.org/fhir", PackageType.CORE, expIg, page.getGenDate().getTime(), true);
+      NPMPackageGenerator npm = new NPMPackageGenerator(Utilities.path(page.getFolders().dstDir, pidRoot() + ".expansions.tgz"), "http://hl7.org/fhir", "http://hl7.org/fhir", PackageType.CORE, expIg, page.getGenDate().getTime(), true);
       Bundle expansionFeed = new Bundle();
       Set<String> urlset = new HashSet<>();
       expansionFeed.setId("valueset-expansions");
@@ -3381,7 +3369,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       npm.finish();
       if (!isCIBuild) {
         String id = pidRoot()+".expansions";
-        new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION).addPackageToCache(id, "current", new FileInputStream(uncheckedPath(page.getFolders().dstDir, id + ".tgz")), uncheckedPath(page.getFolders().dstDir, id + ".tgz"));
+        new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION).addPackageToCache(id, "current", new FileInputStream(Utilities.path(page.getFolders().dstDir, id + ".tgz")), Utilities.path(page.getFolders().dstDir, id + ".tgz"));
       }
       
       serializeResource(expansionFeed, "expansions", false);
@@ -3555,7 +3543,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       exIg.setLicense(ImplementationGuide.SPDXLicense.CC01_0);
       exIg.setTitle("FHIR "+page.getVersion().getDisplay()+" package : Examples");
       exIg.setDescription("Examples for the "+page.getVersion().getDisplay()+" version of the FHIR standard");
-      npm = new NPMPackageGenerator(uncheckedPath(page.getFolders().dstDir, pidRoot() + ".examples.tgz"), "http://hl7.org/fhir", "http://hl7.org/fhir", PackageType.EXAMPLES, exIg, page.getGenDate().getTime(), true);
+      npm = new NPMPackageGenerator(Utilities.path(page.getFolders().dstDir, pidRoot() + ".examples.tgz"), "http://hl7.org/fhir", "http://hl7.org/fhir", PackageType.EXAMPLES, exIg, page.getGenDate().getTime(), true);
 
       zip = new ZipGenerator(page.getFolders().dstDir + "examples-json.zip");
       File f = new CSFile(page.getFolders().dstDir);
@@ -3605,7 +3593,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       spIg.setLicense(ImplementationGuide.SPDXLicense.CC01_0);
       spIg.setTitle("FHIR "+page.getVersion().getDisplay()+" package : ungrouped search parameters");
       exIg.setDescription("FHIR "+page.getVersion().getDisplay()+" package : Search Parameters (break out combined parmaeters for server execution convenience)");
-      npm = new NPMPackageGenerator(uncheckedPath(page.getFolders().dstDir, pidRoot() + ".search.tgz"), "http://hl7.org/fhir", "http://hl7.org/fhir", PackageType.EXAMPLES, exIg, page.getGenDate().getTime(), true);
+      npm = new NPMPackageGenerator(Utilities.path(page.getFolders().dstDir, pidRoot() + ".search.tgz"), "http://hl7.org/fhir", "http://hl7.org/fhir", PackageType.EXAMPLES, exIg, page.getGenDate().getTime(), true);
       for (ResourceDefn r : page.getDefinitions().getBaseResources().values()) {
         addToSearchPackage(r, npm);
       }
@@ -4402,7 +4390,7 @@ public class Publisher implements URIResolver, SectionNumberer {
         page.getHTMLChecker().registerFile(f.getName(), "Support File", HTMLLinkChecker.determineType(n), true);
       }
     } else {
-      Utilities.copyFile(new CSFile(uncheckedPath(folder, n)), new CSFile(page.getFolders().dstDir + (n.contains("/") ? n.substring(n.lastIndexOf("/")+1): n)));
+      Utilities.copyFile(new CSFile(PathBuilder.getPathBuilder().withRequiredTarget(page.getFolders().rootDir).buildPath(folder, n)), new CSFile(page.getFolders().dstDir + (n.contains("/") ? n.substring(n.lastIndexOf("/")+1): n)));
       page.getHTMLChecker().registerFile(n, "Support File", HTMLLinkChecker.determineType(n), true);
     }
   }

--- a/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
@@ -2075,7 +2075,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       json.compose(new FileOutputStream(Utilities.path(page.getFolders().dstDir, baseFileName + ".json")), r);
       if (showCanonical) {
         json.setOutputStyle(OutputStyle.CANONICAL);
-        json.compose(new FileOutputStream(uncheckedPath(page.getFolders().dstDir, baseFileName + ".canonical.json")), r);
+        json.compose(new FileOutputStream(Utilities.path(page.getFolders().dstDir, baseFileName + ".canonical.json")), r);
       }
       if (showTtl) {
         IParser rdf = new RdfParser().setOutputStyle(OutputStyle.PRETTY);
@@ -4837,7 +4837,7 @@ public class Publisher implements URIResolver, SectionNumberer {
 
     StructureDefinitionSpreadsheetGenerator sdr = new StructureDefinitionSpreadsheetGenerator(page.getWorkerContext(), false, false);
     sdr.renderStructureDefinition(resource.getProfile(), false);
-    sdr.finish(new FileOutputStream(uncheckedPath(page.getFolders().dstDir, n + ".xlsx")));
+    sdr.finish(new FileOutputStream(Utilities.path(page.getFolders().dstDir, n + ".xlsx")));
 
     // because we'll pick up a little more information as we process the
     // resource
@@ -4846,12 +4846,12 @@ public class Publisher implements URIResolver, SectionNumberer {
     page.getDiffEngine().getDiffAsJson(diff, p, true);
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
     json = gson.toJson(diff);
-    TextFile.stringToFile(json, uncheckedPath(page.getFolders().dstDir, resource.getName().toLowerCase() + ".r4.diff.json"));
+    TextFile.stringToFile(json, Utilities.path(page.getFolders().dstDir, resource.getName().toLowerCase() + ".r4.diff.json"));
     diff = new com.google.gson.JsonObject();
     page.getDiffEngine().getDiffAsJson(diff, p, false);
     gson = new GsonBuilder().setPrettyPrinting().create();
     json = gson.toJson(diff);
-    TextFile.stringToFile(json, uncheckedPath(page.getFolders().dstDir, resource.getName().toLowerCase() + ".r4b.diff.json"));
+    TextFile.stringToFile(json, Utilities.path(page.getFolders().dstDir, resource.getName().toLowerCase() + ".r4b.diff.json"));
 
     DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
     DocumentBuilder builder = dbf.newDocumentBuilder();
@@ -4859,7 +4859,7 @@ public class Publisher implements URIResolver, SectionNumberer {
     Element element = doc.createElement("difference");
     doc.appendChild(element);
     page.getDiffEngine().getDiffAsXml(doc, element, p, true);
-    prettyPrint(doc, uncheckedPath(page.getFolders().dstDir, resource.getName().toLowerCase() + ".r4.diff.xml"));
+    prettyPrint(doc, Utilities.path(page.getFolders().dstDir, resource.getName().toLowerCase() + ".r4.diff.xml"));
 
     dbf = DocumentBuilderFactory.newInstance();
     builder = dbf.newDocumentBuilder();
@@ -4867,7 +4867,7 @@ public class Publisher implements URIResolver, SectionNumberer {
     element = doc.createElement("difference");
     doc.appendChild(element);
     page.getDiffEngine().getDiffAsXml(doc, element, p, false);
-    prettyPrint(doc, uncheckedPath(page.getFolders().dstDir, resource.getName().toLowerCase() + ".r4b.diff.xml"));
+    prettyPrint(doc, Utilities.path(page.getFolders().dstDir, resource.getName().toLowerCase() + ".r4b.diff.xml"));
 }
 
   public void prettyPrint(Document xml, String filename) throws Exception {
@@ -5302,13 +5302,13 @@ public class Publisher implements URIResolver, SectionNumberer {
     // build json and ttl formats
     e.setResourceName(resn.getName());
     ParserBase xp = Manager.makeParser(page.getWorkerContext(), FhirFormat.XML);
-    org.hl7.fhir.r5.elementmodel.Element exe = xp.parseSingle(new FileInputStream(uncheckedPath(page.getFolders().dstDir, prefix + n + ".xml")));
-    xp.compose(exe, new FileOutputStream(uncheckedPath(page.getFolders().dstDir, prefix + n + ".canonical.xml")), OutputStyle.CANONICAL, null);
+    org.hl7.fhir.r5.elementmodel.Element exe = xp.parseSingle(new FileInputStream(Utilities.path(page.getFolders().dstDir, prefix + n + ".xml")));
+    xp.compose(exe, new FileOutputStream(Utilities.path(page.getFolders().dstDir, prefix + n + ".canonical.xml")), OutputStyle.CANONICAL, null);
     ParserBase jp = Manager.makeParser(page.getWorkerContext(), FhirFormat.JSON);
-    jp.compose(exe, new FileOutputStream(uncheckedPath(page.getFolders().dstDir, prefix + n + ".json")), OutputStyle.PRETTY, null);
-    jp.compose(exe, new FileOutputStream(uncheckedPath(page.getFolders().dstDir, prefix + n + ".canonical.json")), OutputStyle.CANONICAL, null);
+    jp.compose(exe, new FileOutputStream(Utilities.path(page.getFolders().dstDir, prefix + n + ".json")), OutputStyle.PRETTY, null);
+    jp.compose(exe, new FileOutputStream(Utilities.path(page.getFolders().dstDir, prefix + n + ".canonical.json")), OutputStyle.CANONICAL, null);
     ParserBase tp = Manager.makeParser(page.getWorkerContext(), FhirFormat.TURTLE);
-    tp.compose(exe, new FileOutputStream(uncheckedPath(page.getFolders().dstDir, prefix + n + ".ttl")), OutputStyle.PRETTY, null);
+    tp.compose(exe, new FileOutputStream(Utilities.path(page.getFolders().dstDir, prefix + n + ".ttl")), OutputStyle.PRETTY, null);
     
     String json = TextFile.fileToString(page.getFolders().dstDir + prefix+n + ".json");
     //        String json2 = "<div class=\"example\">\r\n<p>" + Utilities.escapeXml(e.getDescription()) + "</p>\r\n<p><a href=\""+ n + ".json\">Raw JSON</a> (<a href=\""+n + ".canonical.json\">Canonical</a>)</p>\r\n<pre class=\"json\" style=\"white-space: pre; overflow: hidden\">\r\n" + Utilities.escapeXml(json)
@@ -6067,7 +6067,9 @@ public class Publisher implements URIResolver, SectionNumberer {
 
     if (lm.getDefinition() != null) {
       //FIXME This makes a path with a blank first entry
-      String fName = uncheckedPath(ig.getPrefix(), n);
+      String fName = ig.getPrefix() != null && ig.getPrefix().length() > 0
+              ? Utilities.path(ig.getPrefix(), n)
+              : n;
       fixCanonicalResource(lm.getDefinition(), fName);
       serializeResource(lm.getDefinition(), fName, "Logical Model "+lm.getDefinition().getName(), "logical-model", lm.getDefinition().getName(), lm.getWg(), false, true);
     }
@@ -6234,7 +6236,7 @@ public class Publisher implements URIResolver, SectionNumberer {
 
 //    TextFile.stringToFile(src, Utilities.path(page.getFolders().dstDir, dstName));
     src = addSectionNumbers(Utilities.path("sid-"+ logicalName+ ".html"), "sid:terminologies-systems", src, "3." + Integer.toString(i), 0, null, null);
-    TextFile.stringToFile(src, uncheckedPath(page.getFolders().dstDir, dstName));
+    TextFile.stringToFile(src, Utilities.path(page.getFolders().dstDir, dstName));
     page.getHTMLChecker().registerFile(Utilities.path("sid-"+ logicalName+ ".html"), logicalName, HTMLLinkChecker.XHTML_TYPE, true);
   }
 

--- a/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
@@ -3354,7 +3354,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       expIg.setLicense(ImplementationGuide.SPDXLicense.CC01_0);
       expIg.setTitle("FHIR "+page.getVersion().getDisplay()+" package : Expansions");
       expIg.setDescription("Expansions for the "+page.getVersion().getDisplay()+" version of the FHIR standard");
-      NPMPackageGenerator npm = new NPMPackageGenerator(Utilities.path(page.getFolders().dstDir, pidRoot() + ".expansions.tgz"), "http://hl7.org/fhir", "http://hl7.org/fhir", PackageType.CORE, expIg, page.getGenDate().getTime(), true);
+      NPMPackageGenerator npm = new NPMPackageGenerator(Utilities.path(page.getFolders().dstDir, pidRoot() + ".expansions.tgz"), "http://hl7.org/fhir", page.getWebLocation(), PackageType.CORE, expIg, page.getGenDate().getTime(), true);
       Bundle expansionFeed = new Bundle();
       Set<String> urlset = new HashSet<>();
       expansionFeed.setId("valueset-expansions");
@@ -3565,7 +3565,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       exIg.setLicense(ImplementationGuide.SPDXLicense.CC01_0);
       exIg.setTitle("FHIR "+page.getVersion().getDisplay()+" package : Examples");
       exIg.setDescription("Examples for the "+page.getVersion().getDisplay()+" version of the FHIR standard");
-      npm = new NPMPackageGenerator(Utilities.path(page.getFolders().dstDir, pidRoot() + ".examples.tgz"), "http://hl7.org/fhir", "http://hl7.org/fhir", PackageType.EXAMPLES, exIg, page.getGenDate().getTime(), true);
+      npm = new NPMPackageGenerator(Utilities.path(page.getFolders().dstDir, pidRoot() + ".examples.tgz"), "http://hl7.org/fhir", page.getWebLocation(), PackageType.EXAMPLES, exIg, page.getGenDate().getTime(), true);
 
       zip = new ZipGenerator(page.getFolders().dstDir + "examples-json.zip");
       File f = new CSFile(page.getFolders().dstDir);
@@ -3615,7 +3615,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       spIg.setLicense(ImplementationGuide.SPDXLicense.CC01_0);
       spIg.setTitle("FHIR "+page.getVersion().getDisplay()+" package : ungrouped search parameters");
       spIg.setDescription("FHIR "+page.getVersion().getDisplay()+" package : Search Parameters (break out combined parameters for server execution convenience)");
-      npm = new NPMPackageGenerator(Utilities.path(page.getFolders().dstDir, pidRoot() + ".search.tgz"), "http://hl7.org/fhir", "http://hl7.org/fhir", PackageType.EXAMPLES, exIg, page.getGenDate().getTime(), true);
+      npm = new NPMPackageGenerator(Utilities.path(page.getFolders().dstDir, pidRoot() + ".search.tgz"), "http://hl7.org/fhir", page.getWebLocation(), PackageType.EXAMPLES, spIg, page.getGenDate().getTime(), true);
       for (ResourceDefn r : page.getDefinitions().getBaseResources().values()) {
         addToSearchPackage(r, npm);
       }

--- a/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
@@ -63,7 +63,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
-import javax.annotation.Nonnull;
 import javax.xml.XMLConstants;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
@@ -868,7 +867,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       page.log("FHIR build failure @ " + Config.DATE_FORMAT().format(Calendar.getInstance().getTime()), LogMessageType.Process);
       System.out.println("Error: " + e.getMessage());
       e.printStackTrace();
-      TextFile.stringToFile(StringUtils.defaultString(e.getMessage()), uncheckedPath(outputdir, "simple-error.txt"));
+      TextFile.stringToFile(StringUtils.defaultString(e.getMessage()), Utilities.path(outputdir, "simple-error.txt"));
       System.exit(1);
     }
   }
@@ -1283,7 +1282,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       if (c == '/')
         level = level +"../";
 
-    String fullFileName = uncheckedPath(page.getFolders().dstDir, n.replace("/", File.separator));
+    String fullFileName = Utilities.path(page.getFolders().dstDir, n.replace("/", File.separator));
     Utilities.createDirectory(fullFileName);
     // simple html version
 //    String pagecnt = "<html>\r\n<head>\r\n<title>Redirect Page for "+Utilities.escapeXml(desc)+" </title>\r\n<meta http-equiv=\"REFRESH\" content=\"0;url="+
@@ -1293,7 +1292,7 @@ public class Publisher implements URIResolver, SectionNumberer {
     String pagecnt = TextFile.fileToString(Utilities.path(page.getFolders().rootDir, "tools", "html", "redirect.asp"));
     pagecnt = pagecnt.replace("<%filename%>", Utilities.changeFileExt(pn, ""));
 
-    String fn = uncheckedPath(fullFileName, "index.asp");
+    String fn = Utilities.path(fullFileName, "index.asp");
     if (!(new File(fn).exists()))
       TextFile.stringToFile(pagecnt, fn);
 
@@ -2037,20 +2036,20 @@ public class Publisher implements URIResolver, SectionNumberer {
     if (VersionUtilities.isR4BVer(page.getVersion().toCode())) {
       org.hl7.fhir.r4.model.Resource r2 = VersionConvertorFactory_40_50.convertResource(r);
       org.hl7.fhir.r4.formats.IParser xml = new org.hl7.fhir.r4.formats.XmlParser().setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.PRETTY);
-      xml.compose(new FileOutputStream(uncheckedPath(page.getFolders().dstDir, baseFileName + ".xml")), r2);
+      xml.compose(new FileOutputStream(Utilities.path(page.getFolders().dstDir, baseFileName + ".xml")), r2);
       if (showCanonical) {
         xml.setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.CANONICAL);
-        xml.compose(new FileOutputStream(uncheckedPath(page.getFolders().dstDir, baseFileName + ".canonical.xml")), r2);
+        xml.compose(new FileOutputStream(Utilities.path(page.getFolders().dstDir, baseFileName + ".canonical.xml")), r2);
       }
       org.hl7.fhir.r4.formats.IParser json = new org.hl7.fhir.r4.formats.JsonParser().setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.PRETTY);
-      json.compose(new FileOutputStream(uncheckedPath(page.getFolders().dstDir, baseFileName + ".json")), r2);
+      json.compose(new FileOutputStream(Utilities.path(page.getFolders().dstDir, baseFileName + ".json")), r2);
       if (showCanonical) {
         json.setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.CANONICAL);
-        json.compose(new FileOutputStream(uncheckedPath(page.getFolders().dstDir, baseFileName + ".canonical.json")), r2);
+        json.compose(new FileOutputStream(Utilities.path(page.getFolders().dstDir, baseFileName + ".canonical.json")), r2);
       }
       if (showTtl) { 
         org.hl7.fhir.r4.formats.IParser rdf = new org.hl7.fhir.r4.formats.RdfParser().setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.PRETTY);
-        rdf.compose(new FileOutputStream(uncheckedPath(page.getFolders().dstDir, baseFileName + ".ttl")), r2);
+        rdf.compose(new FileOutputStream(Utilities.path(page.getFolders().dstDir, baseFileName + ".ttl")), r2);
       }
     } else {
       IParser xml = new XmlParser().setOutputStyle(OutputStyle.PRETTY);
@@ -4408,11 +4407,11 @@ public class Publisher implements URIResolver, SectionNumberer {
         }
       });
       for (File f : files) {
-        Utilities.copyFile(f, new CSFile(uncheckedPath(page.getFolders().dstDir, prefix + f.getName())));
+        Utilities.copyFile(f, new CSFile(Utilities.path(page.getFolders().dstDir, prefix + f.getName())));
         page.getHTMLChecker().registerFile(prefix+f.getName(), "Support File", HTMLLinkChecker.determineType(f.getName()), true);
       }
     } else {
-      Utilities.copyFile(file, new CSFile(uncheckedPath(page.getFolders().dstDir, prefix + file.getName())));
+      Utilities.copyFile(file, new CSFile(Utilities.path(page.getFolders().dstDir, prefix + file.getName())));
       page.getHTMLChecker().registerFile(prefix+file.getName(), "Support File", HTMLLinkChecker.determineType(file.getName()), true);
     }
   }
@@ -5938,7 +5937,7 @@ public class Publisher implements URIResolver, SectionNumberer {
     String logicalName = Utilities.fileTitle(actualName);
     String src;
     if (IgParser.getKind(p) == GuidePageKind.TOC)
-      src = TextFile.fileToString(uncheckedPath(page.getFolders().templateDir, "template-ig-toc.html"));
+      src = TextFile.fileToString(Utilities.path(page.getFolders().templateDir, "template-ig-toc.html"));
     else
       throw new Exception("Unsupported special page kind "+IgParser.getKind(p).toCode());
 
@@ -5950,9 +5949,9 @@ public class Publisher implements URIResolver, SectionNumberer {
 
     src = addSectionNumbers(file, logicalName, src, null, 1, null, ig);
 
-    TextFile.stringToFile(src, uncheckedPath(page.getFolders().dstDir, file));
+    TextFile.stringToFile(src, Utilities.path(page.getFolders().dstDir, file));
 
-    src = TextFile.fileToString(uncheckedPath(page.getFolders().dstDir, file)).replace("<body>", "<body style=\"margin: 10px\">");
+    src = TextFile.fileToString(Utilities.path(page.getFolders().dstDir, file)).replace("<body>", "<body style=\"margin: 10px\">");
     src = page.processPageIncludesForBook(file, src, "page", null, ig, null);
     cachePage(file, src, logicalName, true);
   }
@@ -7101,8 +7100,4 @@ private String csCounter() {
             '}';
   }
 
-  @Nonnull
-  private String uncheckedPath(String folder, String filename) {
-    return Utilities.uncheckedPath(folder, filename);
-  }
 }

--- a/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
@@ -3245,14 +3245,14 @@ public class Publisher implements URIResolver, SectionNumberer {
       Gson gson = new GsonBuilder().setPrettyPrinting().create();
       Gson gsonp = new GsonBuilder().create();
       String json = gson.toJson(diff);
-      TextFile.stringToFile(json, uncheckedPath(page.getFolders().dstDir, "fhir.r4.diff.json"));
+      TextFile.stringToFile(json, Utilities.path(page.getFolders().dstDir, "fhir.r4.diff.json"));
 
       diff = new com.google.gson.JsonObject();
       page.getDiffEngine().getDiffAsJson(diff, false);
       gson = new GsonBuilder().setPrettyPrinting().create();
       gsonp = new GsonBuilder().create();
       json = gson.toJson(diff);
-      TextFile.stringToFile(json, uncheckedPath(page.getFolders().dstDir, "fhir.r4b.diff.json"));
+      TextFile.stringToFile(json, Utilities.path(page.getFolders().dstDir, "fhir.r4b.diff.json"));
 
       DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
       DocumentBuilder builder = dbf.newDocumentBuilder();
@@ -3260,7 +3260,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       Element element = doc.createElement("difference");
       doc.appendChild(element);
       page.getDiffEngine().getDiffAsXml(doc, element, true);
-      prettyPrint(doc, uncheckedPath(page.getFolders().dstDir, "fhir.r4.diff.xml"));
+      prettyPrint(doc, Utilities.path(page.getFolders().dstDir, "fhir.r4.diff.xml"));
 
       dbf = DocumentBuilderFactory.newInstance();
       builder = dbf.newDocumentBuilder();
@@ -3268,7 +3268,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       element = doc.createElement("difference");
       doc.appendChild(element);
       page.getDiffEngine().getDiffAsXml(doc, element, false);
-      prettyPrint(doc, uncheckedPath(page.getFolders().dstDir, "fhir.r4b.diff.xml"));
+      prettyPrint(doc, Utilities.path(page.getFolders().dstDir, "fhir.r4b.diff.xml"));
       
 
       checkBundleURLs(page.getResourceBundle());
@@ -3528,7 +3528,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       zip.addFileName("redirect.asp.template", page.getFolders().srcDir + "redirect.asp", false);
       zip.addFileName("redirect.cgi.template", page.getFolders().srcDir + "redirect.cgi", false);
       zip.addFileName("redirect.php.template", page.getFolders().srcDir + "redirect.php", false);
-      zip.addFileName("ig-template.zip", uncheckedPath(page.getFolders().tmpDir, "ig-template.zip"), false);
+      zip.addFileName("ig-template.zip", Utilities.path(page.getFolders().tmpDir, "ig-template.zip"), false);
       zip.addFiles(page.getFolders().dstDir, "", ".png", null);
       zip.addFiles(page.getFolders().dstDir, "", ".gif", null);
       zip.addBytes("sdmap.details", sdm.asJson().getBytes(StandardCharsets.UTF_8), false);
@@ -3538,7 +3538,8 @@ public class Publisher implements URIResolver, SectionNumberer {
       SpecNPMPackageGenerator self = new SpecNPMPackageGenerator();
       self.generate(page.getFolders().dstDir, page.getWebLocation(), false, page.getGenDate().getTime(), pidRoot());
       if (!isCIBuild) {
-        new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION).addPackageToCache(pidRoot()+".core", "current", new FileInputStream(uncheckedPath(page.getFolders().dstDir, pidRoot() + ".core.tgz")), uncheckedPath(page.getFolders().dstDir, pidRoot() + ".core.tgz"));
+        String packagePath = Utilities.path(page.getFolders().dstDir, pidRoot() + ".core.tgz");
+        new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION).addPackageToCache(pidRoot()+".core", "current", new FileInputStream(packagePath), packagePath);
       }
 
       page.log(" ...zips", LogMessageType.Process);
@@ -4379,7 +4380,7 @@ public class Publisher implements URIResolver, SectionNumberer {
     Utilities.copyDirectory(page.getFolders().rootDir + page.getIni().getStringProperty("html", "source"), page.getFolders().dstDir, page.getHTMLChecker());
     TextFile.stringToFile("\r\n[FHIR]\r\nFhirVersion=" + page.getVersion().toCode() + "\r\nversion=" + page.getVersion().toCode()
         + "\r\nbuildId=" + page.getBuildId() + "\r\ndate=" + new SimpleDateFormat("yyyyMMddHHmmss").format(page.getGenDate().getTime()),
-            uncheckedPath(page.getFolders().dstDir, "version.info"), false);
+            Utilities.path(page.getFolders().dstDir, "version.info"), false);
 
     for (String n : page.getDefinitions().getDiagrams().keySet()) {
       page.log(" ...diagram " + n, LogMessageType.Process);

--- a/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
@@ -63,6 +63,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
+import javax.annotation.Nonnull;
 import javax.xml.XMLConstants;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
@@ -697,7 +698,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       page.log("Create output in "+outputdir, LogMessageType.Process);
     }
     if (apiKeyFile == null) {
-      apiKeyFile = new IniFile(Utilities.uncheckedPath(System.getProperty("user.home"), "fhir-build-keys.ini"));
+      apiKeyFile = new IniFile(Utilities.path(System.getProperty("user.home"), "fhir-build-keys.ini"));
     }
     page.log("API keys loaded from "+apiKeyFile.getFileName(), LogMessageType.Process);
 
@@ -879,7 +880,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       page.log("FHIR build failure @ " + Config.DATE_FORMAT().format(Calendar.getInstance().getTime()), LogMessageType.Process);
       System.out.println("Error: " + e.getMessage());
       e.printStackTrace();
-      TextFile.stringToFile(StringUtils.defaultString(e.getMessage()), Utilities.uncheckedPath(outputdir, "simple-error.txt"));
+      TextFile.stringToFile(StringUtils.defaultString(e.getMessage()), uncheckedPath(outputdir, "simple-error.txt"));
       System.exit(1);
     }
   }
@@ -887,7 +888,7 @@ public class Publisher implements URIResolver, SectionNumberer {
   private void loadMappingExceptionsSchema(String folder) throws IOException {
     try {
       SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-      Schema exceptionsSchema = schemaFactory.newSchema(new File(Utilities.uncheckedPath(folder, MAPPING_EXCEPTIONS_SCHEMA)));
+      Schema exceptionsSchema = schemaFactory.newSchema(new File(Utilities.path(folder, MAPPING_EXCEPTIONS_SCHEMA)));
       mappingExceptionsValidator = exceptionsSchema.newValidator();
     } catch (SAXException e) {
       System.out.println("Error loading schema " + MAPPING_EXCEPTIONS_SCHEMA+": "+e.getMessage());
@@ -1103,7 +1104,7 @@ public class Publisher implements URIResolver, SectionNumberer {
     }
     page.log("    "+invsFound.size()+" invariants found", LogMessageType.Process);
 
-    ZipGenerator zip = new ZipGenerator(Utilities.uncheckedPath(page.getFolders().dstDir, "invariant-tests.zip"));
+    ZipGenerator zip = new ZipGenerator(Utilities.path(page.getFolders().dstDir, "invariant-tests.zip"));
     for (String rname : page.getDefinitions().sortedResourceNames()) {
       if (!ei.testInvariants(page.getFolders().srcDir, page.getDefinitions().getResourceByName(rname), zip, invsTested)) {
         ok = false;
@@ -1294,7 +1295,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       if (c == '/')
         level = level +"../";
 
-    String fullFileName = Utilities.uncheckedPath(page.getFolders().dstDir, n.replace("/", File.separator));
+    String fullFileName = uncheckedPath(page.getFolders().dstDir, n.replace("/", File.separator));
     Utilities.createDirectory(fullFileName);
     // simple html version
 //    String pagecnt = "<html>\r\n<head>\r\n<title>Redirect Page for "+Utilities.escapeXml(desc)+" </title>\r\n<meta http-equiv=\"REFRESH\" content=\"0;url="+
@@ -1304,7 +1305,7 @@ public class Publisher implements URIResolver, SectionNumberer {
     String pagecnt = TextFile.fileToString(Utilities.path(page.getFolders().rootDir, "tools", "html", "redirect.asp"));
     pagecnt = pagecnt.replace("<%filename%>", Utilities.changeFileExt(pn, ""));
 
-    String fn = Utilities.uncheckedPath(fullFileName, "index.asp");
+    String fn = uncheckedPath(fullFileName, "index.asp");
     if (!(new File(fn).exists()))
       TextFile.stringToFile(pagecnt, fn);
 
@@ -1441,7 +1442,7 @@ public class Publisher implements URIResolver, SectionNumberer {
     for (FHIRPathUsage p : fpUsages) {
       checkExpression(b, fp, p);
     }
-    TextFile.stringToFile(b.toString(), Utilities.uncheckedPath(page.getFolders().dstDir, "fhirpaths.txt"));
+    TextFile.stringToFile(b.toString(), Utilities.path(page.getFolders().dstDir, "fhirpaths.txt"));
 
     checkAllOk();
   }
@@ -2048,37 +2049,37 @@ public class Publisher implements URIResolver, SectionNumberer {
     if (VersionUtilities.isR4BVer(page.getVersion().toCode())) {
       org.hl7.fhir.r4.model.Resource r2 = VersionConvertorFactory_40_50.convertResource(r);
       org.hl7.fhir.r4.formats.IParser xml = new org.hl7.fhir.r4.formats.XmlParser().setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.PRETTY);
-      xml.compose(new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, baseFileName + ".xml")), r2);
+      xml.compose(new FileOutputStream(uncheckedPath(page.getFolders().dstDir, baseFileName + ".xml")), r2);
       if (showCanonical) {
         xml.setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.CANONICAL);
-        xml.compose(new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, baseFileName + ".canonical.xml")), r2);
+        xml.compose(new FileOutputStream(uncheckedPath(page.getFolders().dstDir, baseFileName + ".canonical.xml")), r2);
       }
       org.hl7.fhir.r4.formats.IParser json = new org.hl7.fhir.r4.formats.JsonParser().setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.PRETTY);
-      json.compose(new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, baseFileName + ".json")), r2);
+      json.compose(new FileOutputStream(uncheckedPath(page.getFolders().dstDir, baseFileName + ".json")), r2);
       if (showCanonical) {
         json.setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.CANONICAL);
-        json.compose(new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, baseFileName + ".canonical.json")), r2);
+        json.compose(new FileOutputStream(uncheckedPath(page.getFolders().dstDir, baseFileName + ".canonical.json")), r2);
       }
       if (showTtl) { 
         org.hl7.fhir.r4.formats.IParser rdf = new org.hl7.fhir.r4.formats.RdfParser().setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.PRETTY);
-        rdf.compose(new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, baseFileName + ".ttl")), r2);
+        rdf.compose(new FileOutputStream(uncheckedPath(page.getFolders().dstDir, baseFileName + ".ttl")), r2);
       }
     } else {
       IParser xml = new XmlParser().setOutputStyle(OutputStyle.PRETTY);
-      xml.compose(new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, baseFileName + ".xml")), r);
+      xml.compose(new FileOutputStream(Utilities.path(page.getFolders().dstDir, baseFileName + ".xml")), r);
       if (showCanonical) {
         xml.setOutputStyle(OutputStyle.CANONICAL);
-        xml.compose(new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, baseFileName + ".canonical.xml")), r);
+        xml.compose(new FileOutputStream(Utilities.path(page.getFolders().dstDir, baseFileName + ".canonical.xml")), r);
       }
       IParser json = new JsonParser().setOutputStyle(OutputStyle.PRETTY);
-      json.compose(new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, baseFileName + ".json")), r);
+      json.compose(new FileOutputStream(Utilities.path(page.getFolders().dstDir, baseFileName + ".json")), r);
       if (showCanonical) {
         json.setOutputStyle(OutputStyle.CANONICAL);
-        json.compose(new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, baseFileName + ".canonical.json")), r);
+        json.compose(new FileOutputStream(uncheckedPath(page.getFolders().dstDir, baseFileName + ".canonical.json")), r);
       }
       if (showTtl) {
         IParser rdf = new RdfParser().setOutputStyle(OutputStyle.PRETTY);
-        rdf.compose(new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, baseFileName + ".ttl")), r);
+        rdf.compose(new FileOutputStream(Utilities.path(page.getFolders().dstDir, baseFileName + ".ttl")), r);
       }
     }
     if (description!=null) {
@@ -2860,13 +2861,13 @@ public class Publisher implements URIResolver, SectionNumberer {
     shgen.withComments = false;
     TextFile.stringToFile(shgen.generate(HTMLLinkPolicy.NONE, list), page.getFolders().dstDir+"fhir.shex", false);
 
-    new XVerPathsGenerator(page.getDefinitions(), Utilities.uncheckedPath(page.getFolders().dstDir, "xver-paths-" + Constants.VERSION_MM + ".json"), Utilities.path(page.getFolders().rootDir, "tools", "history", "release4b", "xver-paths-4.3.json")).execute();
+    new XVerPathsGenerator(page.getDefinitions(), Utilities.path(page.getFolders().dstDir, "xver-paths-" + Constants.VERSION_MM + ".json"), Utilities.path(page.getFolders().rootDir, "tools", "history", "release4b", "xver-paths-4.3.json")).execute();
     GraphQLSchemaGenerator gql = new GraphQLSchemaGenerator(page.getWorkerContext(), page.getVersion().toCode());
-    gql.generateTypes(new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, "types.graphql")));
+    gql.generateTypes(new FileOutputStream(Utilities.path(page.getFolders().dstDir, "types.graphql")));
     Set<String> names = new HashSet<String>();
     for (StructureDefinition sd : new ContextUtilities(page.getWorkerContext()).allStructures()) {
       if (sd.getKind() == StructureDefinitionKind.RESOURCE && sd.getAbstract() == false && sd.getDerivation() == TypeDerivationRule.SPECIALIZATION && !names.contains(sd.getUrl())) {
-        String filename = Utilities.uncheckedPath(page.getFolders().dstDir, sd.getName().toLowerCase() + ".graphql");
+        String filename = Utilities.path(page.getFolders().dstDir, sd.getName().toLowerCase() + ".graphql");
         names.add(sd.getUrl());
         List<SearchParameter> splist = new ArrayList<SearchParameter>();
         ResourceDefn rd = page.getDefinitions().getResourceByName(sd.getName());
@@ -2884,8 +2885,8 @@ public class Publisher implements URIResolver, SectionNumberer {
       }
     }
 
-    TextFile.stringToFile(page.genBackboneElementsJson(), Utilities.uncheckedPath(page.getFolders().dstDir, "backbone-elements.json"));
-    TextFile.stringToFile(page.genChoiceElementsJson(), Utilities.uncheckedPath(page.getFolders().dstDir, "choice-elements.json"));
+    TextFile.stringToFile(page.genBackboneElementsJson(), Utilities.path(page.getFolders().dstDir, "backbone-elements.json"));
+    TextFile.stringToFile(page.genChoiceElementsJson(), Utilities.path(page.getFolders().dstDir, "choice-elements.json"));
 
     page.log("Produce Schematrons", LogMessageType.Process);
     for (String rname : page.getDefinitions().sortedResourceNames()) {
@@ -3002,23 +3003,23 @@ public class Publisher implements URIResolver, SectionNumberer {
     FhirTurtleGenerator ttl = new FhirTurtleGenerator(tmp, page.getDefinitions(), page.getWorkerContext(), page.getValidationErrors(), page.getWebLocation());
     ttl.executeV3(page.getValueSets(), page.getCodeSystems());
     rim = rim + tmp.toString();
-    TextFile.stringToFile(rim, Utilities.uncheckedPath(page.getFolders().dstDir, "rim.ttl"));
-    ttl = new FhirTurtleGenerator(new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, "fhir.ttl")), page.getDefinitions(), page.getWorkerContext(), page.getValidationErrors(), page.getWebLocation());
+    TextFile.stringToFile(rim, Utilities.path(page.getFolders().dstDir, "rim.ttl"));
+    ttl = new FhirTurtleGenerator(new FileOutputStream(Utilities.path(page.getFolders().dstDir, "fhir.ttl")), page.getDefinitions(), page.getWorkerContext(), page.getValidationErrors(), page.getWebLocation());
     ttl.executeMain();
-    W5TurtleGenerator w5 = new W5TurtleGenerator(new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, "w5.ttl")), page.getDefinitions(), page.getWorkerContext(), page.getValidationErrors(), page.getWebLocation());
+    W5TurtleGenerator w5 = new W5TurtleGenerator(new FileOutputStream(Utilities.path(page.getFolders().dstDir, "w5.ttl")), page.getDefinitions(), page.getWorkerContext(), page.getValidationErrors(), page.getWebLocation());
     w5.executeMain();
     RDFValidator val = new RDFValidator();
-    val.validate(Utilities.uncheckedPath(page.getFolders().dstDir, "fhir.ttl"));
-    val.validate(Utilities.uncheckedPath(page.getFolders().dstDir, "rim.ttl"));
-    val.validate(Utilities.uncheckedPath(page.getFolders().dstDir, "w5.ttl"));
-    ZipGenerator zip = new ZipGenerator(Utilities.uncheckedPath(page.getFolders().dstDir, "fhir.rdf.ttl.zip"));
-    zip.addFileName("fhir.ttl", Utilities.uncheckedPath(page.getFolders().dstDir, "fhir.ttl"), false);
-    zip.addFileName("rim.ttl", Utilities.uncheckedPath(page.getFolders().dstDir, "rim.ttl"), false);
-    zip.addFileName("w5.ttl", Utilities.uncheckedPath(page.getFolders().dstDir, "w5.ttl"), false);
+    val.validate(Utilities.path(page.getFolders().dstDir, "fhir.ttl"));
+    val.validate(Utilities.path(page.getFolders().dstDir, "rim.ttl"));
+    val.validate(Utilities.path(page.getFolders().dstDir, "w5.ttl"));
+    ZipGenerator zip = new ZipGenerator(Utilities.path(page.getFolders().dstDir, "fhir.rdf.ttl.zip"));
+    zip.addFileName("fhir.ttl", Utilities.path(page.getFolders().dstDir, "fhir.ttl"), false);
+    zip.addFileName("rim.ttl", Utilities.path(page.getFolders().dstDir, "rim.ttl"), false);
+    zip.addFileName("w5.ttl", Utilities.path(page.getFolders().dstDir, "w5.ttl"), false);
     zip.close();
 
     // now that the RDF is generated, run any sparql rules that have been defined
-    Element test = loadDom(new FileInputStream(Utilities.uncheckedPath(page.getFolders().srcDir, "sparql-rules.xml")), false).getDocumentElement();
+    Element test = loadDom(new FileInputStream(Utilities.path(page.getFolders().srcDir, "sparql-rules.xml")), false).getDocumentElement();
     test = XMLUtil.getFirstChild(test);
     while (test != null) {
       if (test.getNodeName().equals("assertion")) {
@@ -3244,14 +3245,14 @@ public class Publisher implements URIResolver, SectionNumberer {
       Gson gson = new GsonBuilder().setPrettyPrinting().create();
       Gson gsonp = new GsonBuilder().create();
       String json = gson.toJson(diff);
-      TextFile.stringToFile(json, Utilities.uncheckedPath(page.getFolders().dstDir, "fhir.r4.diff.json"));
+      TextFile.stringToFile(json, uncheckedPath(page.getFolders().dstDir, "fhir.r4.diff.json"));
 
       diff = new com.google.gson.JsonObject();
       page.getDiffEngine().getDiffAsJson(diff, false);
       gson = new GsonBuilder().setPrettyPrinting().create();
       gsonp = new GsonBuilder().create();
       json = gson.toJson(diff);
-      TextFile.stringToFile(json, Utilities.uncheckedPath(page.getFolders().dstDir, "fhir.r4b.diff.json"));
+      TextFile.stringToFile(json, uncheckedPath(page.getFolders().dstDir, "fhir.r4b.diff.json"));
 
       DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
       DocumentBuilder builder = dbf.newDocumentBuilder();
@@ -3259,7 +3260,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       Element element = doc.createElement("difference");
       doc.appendChild(element);
       page.getDiffEngine().getDiffAsXml(doc, element, true);
-      prettyPrint(doc, Utilities.uncheckedPath(page.getFolders().dstDir, "fhir.r4.diff.xml"));
+      prettyPrint(doc, uncheckedPath(page.getFolders().dstDir, "fhir.r4.diff.xml"));
 
       dbf = DocumentBuilderFactory.newInstance();
       builder = dbf.newDocumentBuilder();
@@ -3267,7 +3268,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       element = doc.createElement("difference");
       doc.appendChild(element);
       page.getDiffEngine().getDiffAsXml(doc, element, false);
-      prettyPrint(doc, Utilities.uncheckedPath(page.getFolders().dstDir, "fhir.r4b.diff.xml"));
+      prettyPrint(doc, uncheckedPath(page.getFolders().dstDir, "fhir.r4b.diff.xml"));
       
 
       checkBundleURLs(page.getResourceBundle());
@@ -3343,7 +3344,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       expIg.setLicense(ImplementationGuide.SPDXLicense.CC01_0);
       expIg.setTitle("FHIR "+page.getVersion().getDisplay()+" package : Expansions");
       expIg.setDescription("Expansions for the "+page.getVersion().getDisplay()+" version of the FHIR standard");
-      NPMPackageGenerator npm = new NPMPackageGenerator(Utilities.uncheckedPath(page.getFolders().dstDir, pidRoot() + ".expansions.tgz"), "http://hl7.org/fhir", "http://hl7.org/fhir", PackageType.CORE, expIg, page.getGenDate().getTime(), true);
+      NPMPackageGenerator npm = new NPMPackageGenerator(uncheckedPath(page.getFolders().dstDir, pidRoot() + ".expansions.tgz"), "http://hl7.org/fhir", "http://hl7.org/fhir", PackageType.CORE, expIg, page.getGenDate().getTime(), true);
       Bundle expansionFeed = new Bundle();
       Set<String> urlset = new HashSet<>();
       expansionFeed.setId("valueset-expansions");
@@ -3380,7 +3381,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       npm.finish();
       if (!isCIBuild) {
         String id = pidRoot()+".expansions";
-        new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION).addPackageToCache(id, "current", new FileInputStream(Utilities.uncheckedPath(page.getFolders().dstDir, id + ".tgz")), Utilities.uncheckedPath(page.getFolders().dstDir, id + ".tgz"));
+        new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION).addPackageToCache(id, "current", new FileInputStream(uncheckedPath(page.getFolders().dstDir, id + ".tgz")), uncheckedPath(page.getFolders().dstDir, id + ".tgz"));
       }
       
       serializeResource(expansionFeed, "expansions", false);
@@ -3527,7 +3528,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       zip.addFileName("redirect.asp.template", page.getFolders().srcDir + "redirect.asp", false);
       zip.addFileName("redirect.cgi.template", page.getFolders().srcDir + "redirect.cgi", false);
       zip.addFileName("redirect.php.template", page.getFolders().srcDir + "redirect.php", false);
-      zip.addFileName("ig-template.zip", Utilities.uncheckedPath(page.getFolders().tmpDir, "ig-template.zip"), false);
+      zip.addFileName("ig-template.zip", uncheckedPath(page.getFolders().tmpDir, "ig-template.zip"), false);
       zip.addFiles(page.getFolders().dstDir, "", ".png", null);
       zip.addFiles(page.getFolders().dstDir, "", ".gif", null);
       zip.addBytes("sdmap.details", sdm.asJson().getBytes(StandardCharsets.UTF_8), false);
@@ -3537,7 +3538,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       SpecNPMPackageGenerator self = new SpecNPMPackageGenerator();
       self.generate(page.getFolders().dstDir, page.getWebLocation(), false, page.getGenDate().getTime(), pidRoot());
       if (!isCIBuild) {
-        new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION).addPackageToCache(pidRoot()+".core", "current", new FileInputStream(Utilities.uncheckedPath(page.getFolders().dstDir, pidRoot() + ".core.tgz")), Utilities.uncheckedPath(page.getFolders().dstDir, pidRoot() + ".core.tgz"));
+        new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION).addPackageToCache(pidRoot()+".core", "current", new FileInputStream(uncheckedPath(page.getFolders().dstDir, pidRoot() + ".core.tgz")), uncheckedPath(page.getFolders().dstDir, pidRoot() + ".core.tgz"));
       }
 
       page.log(" ...zips", LogMessageType.Process);
@@ -3553,7 +3554,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       exIg.setLicense(ImplementationGuide.SPDXLicense.CC01_0);
       exIg.setTitle("FHIR "+page.getVersion().getDisplay()+" package : Examples");
       exIg.setDescription("Examples for the "+page.getVersion().getDisplay()+" version of the FHIR standard");
-      npm = new NPMPackageGenerator(Utilities.uncheckedPath(page.getFolders().dstDir, pidRoot() + ".examples.tgz"), "http://hl7.org/fhir", "http://hl7.org/fhir", PackageType.EXAMPLES, exIg, page.getGenDate().getTime(), true);
+      npm = new NPMPackageGenerator(uncheckedPath(page.getFolders().dstDir, pidRoot() + ".examples.tgz"), "http://hl7.org/fhir", "http://hl7.org/fhir", PackageType.EXAMPLES, exIg, page.getGenDate().getTime(), true);
 
       zip = new ZipGenerator(page.getFolders().dstDir + "examples-json.zip");
       File f = new CSFile(page.getFolders().dstDir);
@@ -3603,7 +3604,7 @@ public class Publisher implements URIResolver, SectionNumberer {
       spIg.setLicense(ImplementationGuide.SPDXLicense.CC01_0);
       spIg.setTitle("FHIR "+page.getVersion().getDisplay()+" package : ungrouped search parameters");
       exIg.setDescription("FHIR "+page.getVersion().getDisplay()+" package : Search Parameters (break out combined parmaeters for server execution convenience)");
-      npm = new NPMPackageGenerator(Utilities.uncheckedPath(page.getFolders().dstDir, pidRoot() + ".search.tgz"), "http://hl7.org/fhir", "http://hl7.org/fhir", PackageType.EXAMPLES, exIg, page.getGenDate().getTime(), true);
+      npm = new NPMPackageGenerator(uncheckedPath(page.getFolders().dstDir, pidRoot() + ".search.tgz"), "http://hl7.org/fhir", "http://hl7.org/fhir", PackageType.EXAMPLES, exIg, page.getGenDate().getTime(), true);
       for (ResourceDefn r : page.getDefinitions().getBaseResources().values()) {
         addToSearchPackage(r, npm);
       }
@@ -4378,7 +4379,7 @@ public class Publisher implements URIResolver, SectionNumberer {
     Utilities.copyDirectory(page.getFolders().rootDir + page.getIni().getStringProperty("html", "source"), page.getFolders().dstDir, page.getHTMLChecker());
     TextFile.stringToFile("\r\n[FHIR]\r\nFhirVersion=" + page.getVersion().toCode() + "\r\nversion=" + page.getVersion().toCode()
         + "\r\nbuildId=" + page.getBuildId() + "\r\ndate=" + new SimpleDateFormat("yyyyMMddHHmmss").format(page.getGenDate().getTime()),
-            Utilities.uncheckedPath(page.getFolders().dstDir, "version.info"), false);
+            uncheckedPath(page.getFolders().dstDir, "version.info"), false);
 
     for (String n : page.getDefinitions().getDiagrams().keySet()) {
       page.log(" ...diagram " + n, LogMessageType.Process);
@@ -4400,7 +4401,7 @@ public class Publisher implements URIResolver, SectionNumberer {
         page.getHTMLChecker().registerFile(f.getName(), "Support File", HTMLLinkChecker.determineType(n), true);
       }
     } else {
-      Utilities.copyFile(new CSFile(Utilities.uncheckedPath(folder, n)), new CSFile(page.getFolders().dstDir + (n.contains("/") ? n.substring(n.lastIndexOf("/")+1): n)));
+      Utilities.copyFile(new CSFile(uncheckedPath(folder, n)), new CSFile(page.getFolders().dstDir + (n.contains("/") ? n.substring(n.lastIndexOf("/")+1): n)));
       page.getHTMLChecker().registerFile(n, "Support File", HTMLLinkChecker.determineType(n), true);
     }
   }
@@ -4418,11 +4419,11 @@ public class Publisher implements URIResolver, SectionNumberer {
         }
       });
       for (File f : files) {
-        Utilities.copyFile(f, new CSFile(Utilities.uncheckedPath(page.getFolders().dstDir, prefix + f.getName())));
+        Utilities.copyFile(f, new CSFile(uncheckedPath(page.getFolders().dstDir, prefix + f.getName())));
         page.getHTMLChecker().registerFile(prefix+f.getName(), "Support File", HTMLLinkChecker.determineType(f.getName()), true);
       }
     } else {
-      Utilities.copyFile(file, new CSFile(Utilities.uncheckedPath(page.getFolders().dstDir, prefix + file.getName())));
+      Utilities.copyFile(file, new CSFile(uncheckedPath(page.getFolders().dstDir, prefix + file.getName())));
       page.getHTMLChecker().registerFile(prefix+file.getName(), "Support File", HTMLLinkChecker.determineType(file.getName()), true);
     }
   }
@@ -4664,7 +4665,7 @@ public class Publisher implements URIResolver, SectionNumberer {
     zip = new ZipGenerator(page.getFolders().dstDir + "fhir.schema.shex.zip");
     for (String fn : new File(page.getFolders().dstDir).list()) {
       if (fn.endsWith(".shex")) {
-        zip.addFileName(fn, Utilities.uncheckedPath(page.getFolders().dstDir, fn), false);
+        zip.addFileName(fn, Utilities.path(page.getFolders().dstDir, fn), false);
       }
     }
     zip.close();
@@ -4836,7 +4837,7 @@ public class Publisher implements URIResolver, SectionNumberer {
 
     StructureDefinitionSpreadsheetGenerator sdr = new StructureDefinitionSpreadsheetGenerator(page.getWorkerContext(), false, false);
     sdr.renderStructureDefinition(resource.getProfile(), false);
-    sdr.finish(new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, n + ".xlsx")));
+    sdr.finish(new FileOutputStream(uncheckedPath(page.getFolders().dstDir, n + ".xlsx")));
 
     // because we'll pick up a little more information as we process the
     // resource
@@ -4845,12 +4846,12 @@ public class Publisher implements URIResolver, SectionNumberer {
     page.getDiffEngine().getDiffAsJson(diff, p, true);
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
     json = gson.toJson(diff);
-    TextFile.stringToFile(json, Utilities.uncheckedPath(page.getFolders().dstDir, resource.getName().toLowerCase() + ".r4.diff.json"));
+    TextFile.stringToFile(json, uncheckedPath(page.getFolders().dstDir, resource.getName().toLowerCase() + ".r4.diff.json"));
     diff = new com.google.gson.JsonObject();
     page.getDiffEngine().getDiffAsJson(diff, p, false);
     gson = new GsonBuilder().setPrettyPrinting().create();
     json = gson.toJson(diff);
-    TextFile.stringToFile(json, Utilities.uncheckedPath(page.getFolders().dstDir, resource.getName().toLowerCase() + ".r4b.diff.json"));
+    TextFile.stringToFile(json, uncheckedPath(page.getFolders().dstDir, resource.getName().toLowerCase() + ".r4b.diff.json"));
 
     DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
     DocumentBuilder builder = dbf.newDocumentBuilder();
@@ -4858,7 +4859,7 @@ public class Publisher implements URIResolver, SectionNumberer {
     Element element = doc.createElement("difference");
     doc.appendChild(element);
     page.getDiffEngine().getDiffAsXml(doc, element, p, true);
-    prettyPrint(doc, Utilities.uncheckedPath(page.getFolders().dstDir, resource.getName().toLowerCase() + ".r4.diff.xml"));
+    prettyPrint(doc, uncheckedPath(page.getFolders().dstDir, resource.getName().toLowerCase() + ".r4.diff.xml"));
 
     dbf = DocumentBuilderFactory.newInstance();
     builder = dbf.newDocumentBuilder();
@@ -4866,7 +4867,7 @@ public class Publisher implements URIResolver, SectionNumberer {
     element = doc.createElement("difference");
     doc.appendChild(element);
     page.getDiffEngine().getDiffAsXml(doc, element, p, false);
-    prettyPrint(doc, Utilities.uncheckedPath(page.getFolders().dstDir, resource.getName().toLowerCase() + ".r4b.diff.xml"));
+    prettyPrint(doc, uncheckedPath(page.getFolders().dstDir, resource.getName().toLowerCase() + ".r4b.diff.xml"));
 }
 
   public void prettyPrint(Document xml, String filename) throws Exception {
@@ -5301,13 +5302,13 @@ public class Publisher implements URIResolver, SectionNumberer {
     // build json and ttl formats
     e.setResourceName(resn.getName());
     ParserBase xp = Manager.makeParser(page.getWorkerContext(), FhirFormat.XML);
-    org.hl7.fhir.r5.elementmodel.Element exe = xp.parseSingle(new FileInputStream(Utilities.uncheckedPath(page.getFolders().dstDir, prefix + n + ".xml")));
-    xp.compose(exe, new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, prefix + n + ".canonical.xml")), OutputStyle.CANONICAL, null);
+    org.hl7.fhir.r5.elementmodel.Element exe = xp.parseSingle(new FileInputStream(uncheckedPath(page.getFolders().dstDir, prefix + n + ".xml")));
+    xp.compose(exe, new FileOutputStream(uncheckedPath(page.getFolders().dstDir, prefix + n + ".canonical.xml")), OutputStyle.CANONICAL, null);
     ParserBase jp = Manager.makeParser(page.getWorkerContext(), FhirFormat.JSON);
-    jp.compose(exe, new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, prefix + n + ".json")), OutputStyle.PRETTY, null);
-    jp.compose(exe, new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, prefix + n + ".canonical.json")), OutputStyle.CANONICAL, null);
+    jp.compose(exe, new FileOutputStream(uncheckedPath(page.getFolders().dstDir, prefix + n + ".json")), OutputStyle.PRETTY, null);
+    jp.compose(exe, new FileOutputStream(uncheckedPath(page.getFolders().dstDir, prefix + n + ".canonical.json")), OutputStyle.CANONICAL, null);
     ParserBase tp = Manager.makeParser(page.getWorkerContext(), FhirFormat.TURTLE);
-    tp.compose(exe, new FileOutputStream(Utilities.uncheckedPath(page.getFolders().dstDir, prefix + n + ".ttl")), OutputStyle.PRETTY, null);
+    tp.compose(exe, new FileOutputStream(uncheckedPath(page.getFolders().dstDir, prefix + n + ".ttl")), OutputStyle.PRETTY, null);
     
     String json = TextFile.fileToString(page.getFolders().dstDir + prefix+n + ".json");
     //        String json2 = "<div class=\"example\">\r\n<p>" + Utilities.escapeXml(e.getDescription()) + "</p>\r\n<p><a href=\""+ n + ".json\">Raw JSON</a> (<a href=\""+n + ".canonical.json\">Canonical</a>)</p>\r\n<pre class=\"json\" style=\"white-space: pre; overflow: hidden\">\r\n" + Utilities.escapeXml(json)
@@ -5948,7 +5949,7 @@ public class Publisher implements URIResolver, SectionNumberer {
     String logicalName = Utilities.fileTitle(actualName);
     String src;
     if (IgParser.getKind(p) == GuidePageKind.TOC)
-      src = TextFile.fileToString(Utilities.uncheckedPath(page.getFolders().templateDir, "template-ig-toc.html"));
+      src = TextFile.fileToString(uncheckedPath(page.getFolders().templateDir, "template-ig-toc.html"));
     else
       throw new Exception("Unsupported special page kind "+IgParser.getKind(p).toCode());
 
@@ -5960,9 +5961,9 @@ public class Publisher implements URIResolver, SectionNumberer {
 
     src = addSectionNumbers(file, logicalName, src, null, 1, null, ig);
 
-    TextFile.stringToFile(src, Utilities.uncheckedPath(page.getFolders().dstDir, file));
+    TextFile.stringToFile(src, uncheckedPath(page.getFolders().dstDir, file));
 
-    src = TextFile.fileToString(Utilities.uncheckedPath(page.getFolders().dstDir, file)).replace("<body>", "<body style=\"margin: 10px\">");
+    src = TextFile.fileToString(uncheckedPath(page.getFolders().dstDir, file)).replace("<body>", "<body style=\"margin: 10px\">");
     src = page.processPageIncludesForBook(file, src, "page", null, ig, null);
     cachePage(file, src, logicalName, true);
   }
@@ -6065,7 +6066,8 @@ public class Publisher implements URIResolver, SectionNumberer {
     page.getSectionTrackerCache().put(fn, st);
 
     if (lm.getDefinition() != null) {
-      String fName = Utilities.uncheckedPath(ig.getPrefix(), n);
+      //FIXME This makes a path with a blank first entry
+      String fName = uncheckedPath(ig.getPrefix(), n);
       fixCanonicalResource(lm.getDefinition(), fName);
       serializeResource(lm.getDefinition(), fName, "Logical Model "+lm.getDefinition().getName(), "logical-model", lm.getDefinition().getName(), lm.getWg(), false, true);
     }
@@ -6232,7 +6234,7 @@ public class Publisher implements URIResolver, SectionNumberer {
 
 //    TextFile.stringToFile(src, Utilities.path(page.getFolders().dstDir, dstName));
     src = addSectionNumbers(Utilities.path("sid-"+ logicalName+ ".html"), "sid:terminologies-systems", src, "3." + Integer.toString(i), 0, null, null);
-    TextFile.stringToFile(src, Utilities.uncheckedPath(page.getFolders().dstDir, dstName));
+    TextFile.stringToFile(src, uncheckedPath(page.getFolders().dstDir, dstName));
     page.getHTMLChecker().registerFile(Utilities.path("sid-"+ logicalName+ ".html"), logicalName, HTMLLinkChecker.XHTML_TYPE, true);
   }
 
@@ -7106,5 +7108,10 @@ private String csCounter() {
             ",\n examplesProcessed=" + examplesProcessed +
             ",\n validationMode=" + validationMode +
             '}';
+  }
+
+  @Nonnull
+  private String uncheckedPath(String folder, String filename) {
+    return Utilities.uncheckedPath(folder, filename);
   }
 }


### PR DESCRIPTION
In previous work, some paths being built during the publishing process were throwing exceptions for violating the checks required of the new zip-slip-safe Utilities.path method. These were aggressively replaced with uncheckedPath calls until kindling publish jobs would complete. 

THIS PR REQUIRES THIS PR TO BE MERGED BEFORE WORKING: https://github.com/hapifhir/org.hl7.fhir.core/pull/1183

This PR replaces those with either:
* checked Utilities.path(...) calls
* fixes to logic that would have created exceptions in Utilities.path(...)
* finer-grained PathBuilder calls that still protect the publishing process from writing to higher-level directories.