### PR TITLE
Support adding new resource definitions (again)

### DIFF
--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/ProfileGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/ProfileGenerator.java
@@ -1481,7 +1481,7 @@ public class ProfileGenerator {
           boolean found = false;
           for (Enumeration<VersionIndependentResourceTypesAll> st : sp.getTarget())
             found = found || st.asStringValue().equals(resourceName);
-          if (!found)
+          if (!found && VersionIndependentResourceTypesAll.isValidCode(resourceName))
             sp.addTarget(VersionIndependentResourceTypesAll.fromCode(resourceName));
         }
       }
@@ -1489,8 +1489,8 @@ public class ProfileGenerator {
         boolean found = false;
         for (Enumeration<VersionIndependentResourceTypesAll> st : sp.getTarget())
           found = found || st.asStringValue().equals(target);
-        if (!found)
-          sp.addTarget(VersionIndependentResourceTypesAll.fromCode(target));
+          if (!found && VersionIndependentResourceTypesAll.isValidCode(target))
+            sp.addTarget(VersionIndependentResourceTypesAll.fromCode(target));
       }
     }
     context.cacheResource(sp);

--- a/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/Publisher.java
@@ -1041,17 +1041,20 @@ public class Publisher implements URIResolver, SectionNumberer {
               String tn = tail(t);
               if (tn.equals("Resource")) {
                 for (String s : cu.getConcreteResources()) {
-                  if (!sp.hasTarget(VersionIndependentResourceTypesAll.fromCode(s))) {
+                  if (VersionIndependentResourceTypesAll.isValidCode(s)
+                  &&  !sp.hasTarget(VersionIndependentResourceTypesAll.fromCode(s))) {
                     sp.addTarget(VersionIndependentResourceTypesAll.fromCode(s));
                   }
                 }
               } else if (tn.equals("CanonicalResource")) {
                 for (String s : cu.getCanonicalResourceNames()) {
-                  if (!sp.hasTarget(VersionIndependentResourceTypesAll.fromCode(s))) {
+                  if (VersionIndependentResourceTypesAll.isValidCode(s)
+                  &&  !sp.hasTarget(VersionIndependentResourceTypesAll.fromCode(s))) {
                     sp.addTarget(VersionIndependentResourceTypesAll.fromCode(s));
                   }
                 }
-              } else if (!sp.hasTarget(VersionIndependentResourceTypesAll.fromCode(tn))) { 
+              } else if (VersionIndependentResourceTypesAll.isValidCode(tn)
+                  &&  !sp.hasTarget(VersionIndependentResourceTypesAll.fromCode(tn))) { 
                 sp.addTarget(VersionIndependentResourceTypesAll.fromCode(tn));
               }
             }


### PR DESCRIPTION
Support adding new resource definitions to the spec without requiring a new build of the core libraries (specifically the VersionIndependentResourceTypesAll enumeration)

`fromCode` fails if it is provided a value that doesn't exist in the compiled code.