### PR TITLE
Changed xml mapping writer to use System.lineSeparator instead of \n.

### DIFF
--- a/src/main/java/org/hl7/fhir/tools/publisher/PageProcessor.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/PageProcessor.java
@@ -6802,7 +6802,7 @@ public class PageProcessor implements Logger, ProfileKnowledgeProvider, IReferen
 
           java.io.Writer writer = new java.io.FileWriter(exceptionsFile);
           final LSSerializer xmlWriter = impl.createLSSerializer();
-          xmlWriter.setNewLine("\n");
+          xmlWriter.setNewLine(System.lineSeparator());
           xmlWriter.getDomConfig().setParameter("format-pretty-print", true);
           xmlWriter.getDomConfig().setParameter("xml-declaration", false);
           String xml = xmlWriter.writeToString(newExceptionsDoc);


### PR DESCRIPTION
Made this change to prevent newline changes on Windows systems.  Am not set up to build/test locally, so please merge with caution.