### PR TITLE
Update gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-fhirCoreVersion = 6.4.1-SNAPSHOT
+fhirCoreVersion = 6.4.1
 apachePoiVersion = 5.2.1
 jacksonVersion = 2.16.0
 apacheHttpcomponentsVersion = 4.5.13


### PR DESCRIPTION
Don't use SNAPSHOT (sonatype has removed this and a few other SNAPSHOT deployments)