### PR TITLE
Fix multiple slf4j impls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -489,11 +489,7 @@
             <artifactId>slf4j-jdk14</artifactId>
             <version>${slf4jVersion}</version>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4jVersion}</version>
-        </dependency>
+
         <dependency>
             <groupId>org.slf4s</groupId>
             <artifactId>slf4s-api_2.11</artifactId>


### PR DESCRIPTION
Our dependencies include extra slf4j implementations, which cause warnings to be printed when kindling is run.

This drops log4j12 in favour of slf4j-jdk14