### PR TITLE
Issue #189 - Fix tx server url suffix

### DIFF
--- a/src/main/java/org/hl7/fhir/tools/publisher/KindlingConstants.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/KindlingConstants.java
@@ -3,7 +3,7 @@ package org.hl7.fhir.tools.publisher;
 import org.hl7.fhir.utilities.settings.FhirSettings;
 
 public class KindlingConstants {
-  
-  public final static String DEF_TS_SERVER = FhirSettings.getTxFhirProduction()+"/r4"; 
+
+  public final static String DEF_TS_SERVER = FhirSettings.getTxFhirProduction()+"/r5";
 
 }


### PR DESCRIPTION
### What does this Pull Request do?
- Update the KindlingConstants static variable DEV_TS_SERVER suffix from "/r4" to "/r5".

### Why?
- Corrects build failure with validation errors due to an invalid terminology server url path.

### Issue Number(s)
[#189](https://github.com/HL7/kindling/issues/189)