### PR TITLE
R6 RDF Ontology fix fhir:treeRoot

### DIFF
--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
@@ -163,17 +163,20 @@ public class FhirTurtleGenerator {
 
 
         // A resource can have an optional nodeRole
-        FHIRResource treeRoot = fact.fhir_class_with_provenance("treeRoot", fhirRdfPageUrl)
-                .addTitle("Class of FHIR base documents")
+        FHIRResource treeRoot = fact.fhir_individual("treeRoot")
+                .addTitle("Root resource of FHIR RDF document")
                 .addDataProperty(RDFS.comment, "Some resources can contain other resources. Given that the relationships can appear in any order in RDF, it cannot be assumed that the first encountered element represents the resource of interest that is being represented by the set of Turtle statements. The focal resource -- where to start when parsing -- is the resource with the relationship fhir:nodeRole to fhir:treeRoot. If there is more than one node labeled as a 'treeRoot' in a set of Turtle statements, it cannot be determined how to parse them as a single resource.");
 
         FHIRResource nodeRole = fact.fhir_objectProperty("nodeRole", fhirRdfPageUrl)
                 .addTitle("Identifies role of subject in context of a given document")
                 .domain(Resource)
-                .range(treeRoot.resource);
-        Resource.restriction(fact.fhir_class_cardinality_restriction(nodeRole.resource, treeRoot.resource, 0, 1));
+                .rangeIndividual(treeRoot.resource);
 
-
+        // Resource can have max 1 nodeRole
+        Resource.restriction(fact.create_empty_owl_restriction(nodeRole.resource).addDataProperty(OWL2.maxCardinality, "1", XSDDatatype.XSDinteger).resource);
+        // Resource nodeRole can only the individual treeRoot
+        Resource.restriction(fact.create_empty_owl_restriction(nodeRole.resource).addObjectProperty(OWL2.allValuesFrom, treeRoot.oneOfIndividual(treeRoot.resource)).resource);
+        
         // Any element can have an index to assign order in a list
 //        FHIRResource index = fact.fhir_dataProperty("index")
 //                .addTitle("Ordering value for list")

--- a/src/main/java/org/hl7/fhir/rdf/FHIRResource.java
+++ b/src/main/java/org/hl7/fhir/rdf/FHIRResource.java
@@ -1,5 +1,6 @@
 package org.hl7.fhir.rdf;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -9,6 +10,7 @@ import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.DC;
+import org.apache.jena.vocabulary.OWL2;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
 import org.hl7.fhir.utilities.Utilities;
@@ -116,6 +118,20 @@ public class FHIRResource {
 
     public FHIRResource range(Resource r) {
         return addObjectProperty(RDFS.range, r);
+    }
+
+    public FHIRResource rangeIndividual(Resource r) {
+        Resource blankNode = oneOfIndividual(r);
+        resource.addProperty(RDFS.range, blankNode);
+        return this;
+    }
+
+    public Resource oneOfIndividual(Resource r) {
+        Resource blankNode = resource.getModel().createResource();
+        blankNode.addProperty(RDF.type, OWL2.Class);
+        Resource individuals = resource.getModel().createList(new ArrayList<Resource>() {{ add(r); } }.iterator());
+        blankNode.addProperty(OWL2.oneOf, individuals);
+        return blankNode;
     }
 
     public FHIRResource restriction(Resource restriction) {

--- a/src/main/java/org/hl7/fhir/rdf/FHIRResourceFactory.java
+++ b/src/main/java/org/hl7/fhir/rdf/FHIRResourceFactory.java
@@ -94,6 +94,11 @@ public class FHIRResourceFactory {
         return fhir_resource(name, OWL2.Class, name);
     }
 
+    public FHIRResource fhir_individual(String name) {
+        return fhir_resource(name, OWL2.NamedIndividual, name);
+    }
+
+
     /**
      * Create a new Class in the FHIR namespace
      *


### PR DESCRIPTION
Minor fix that affects ONLY the [FHIR RDF Ontology](https://build.fhir.org/rdf.html#ontologies) https://build.fhir.org/fhir.ttl , not even FHIR Turtle serialization or ShEx. This also does not correspond to anything in FHIR - it's specific to RDF Turtle to help with parsing the root resource of a document: https://build.fhir.org/rdf.html#resources

Changes fhir:treeRoot to an individual and not a class, since object properties can only be used with individuals in OWL: https://github.com/w3c/hcls-fhir-rdf/issues/202