### PR TITLE
Version bumps + dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <apacheHttpcomponentsVersion>4.5.13</apacheHttpcomponentsVersion>
         <apacheHttpcomponents5Version>5.0.4</apacheHttpcomponents5Version>
         <apacheJenaVersion>5.6.0</apacheJenaVersion>
-        <log4jVersion>2.25.4</log4jVersion>
+        <log4jVersion>2.26.0</log4jVersion>
         <lombok_version>1.18.38</lombok_version>
         <slf4jVersion>1.7.36</slf4jVersion>
         <jettyVersion>12.0.33</jettyVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -10,15 +10,16 @@
     <properties>
         <fhirCoreVersion>6.9.1-SNAPSHOT</fhirCoreVersion>
         <apachePoiVersion>5.4.1</apachePoiVersion>
-        <jacksonVersion>2.16.0</jacksonVersion>
+        <jacksonAnnotationsVersion>2.21</jacksonAnnotationsVersion>
+        <jacksonVersion>2.21.3</jacksonVersion>
         <apacheHttpcomponentsVersion>4.5.13</apacheHttpcomponentsVersion>
         <apacheHttpcomponents5Version>5.0.4</apacheHttpcomponents5Version>
         <apacheJenaVersion>5.6.0</apacheJenaVersion>
-        <log4jVersion>2.25.3</log4jVersion>
+        <log4jVersion>2.25.4</log4jVersion>
         <lombok_version>1.18.38</lombok_version>
         <slf4jVersion>1.7.36</slf4jVersion>
-        <jettyVersion>12.0.29</jettyVersion>
-        <logbackVersion>1.5.20</logbackVersion>
+        <jettyVersion>12.0.33</jettyVersion>
+        <logbackVersion>1.5.25</logbackVersion>
         <nettyConstrainedVersion>4.1.118.Final</nettyConstrainedVersion>
         <maven.compiler.release>17</maven.compiler.release>
         <maven.compiler.source>17</maven.compiler.source>
@@ -54,7 +55,7 @@
             <id>github-releases</id>
             <url>https://maven.pkg.github.com/hapifhir/org.hl7.fhir.core/</url>
         </repository>
-        <repository>
+<repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
             <snapshots>
@@ -88,6 +89,12 @@
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio-jvm</artifactId>
                 <version>3.4.0</version>
+            </dependency>
+            <!-- Fixes older 2.2.20 in okio-->
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>2.2.21</version>
             </dependency>
             <dependency>
                 <groupId>commons-beanutils</groupId>
@@ -218,7 +225,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jacksonVersion}</version>
+            <version>${jacksonAnnotationsVersion}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
jacksonAnnotationsVersion > 2.21
jacksonVersion -> 2.21.3
log4jVersion -> 2.25.4
jettyVersion -> 12.0.33
logbackVersion -> 1.5.25

dependencyManagement
kotlin-stdlib -> 2.2.21

On the current fhir spec, this produces the same issues summary:

`Errors: 0 Warnings: 119 Hints: 778`