### PR TITLE
Report unrelated validation errors in invariant fixtures

### DIFF
--- a/src/main/java/org/hl7/fhir/tools/publisher/ExampleInspector.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/ExampleInspector.java
@@ -721,7 +721,7 @@ public class ExampleInspector implements IValidatorResourceFetcher, IValidationP
       validator.setAllowXsiLocation(true);
       validator.validate(null, errs, new FileInputStream(f), fmt);
 
-      List<ValidationMessage> unexpectedErrors = findUnexpectedInvariantFixtureErrors(inv, errs);
+      List<ValidationMessage> unexpectedErrors = findUnexpectedInvariantFixtureErrors(f.getName(), inv, errs);
       if (!unexpectedErrors.isEmpty()) {
         System.out.println("Test case '"+f.getName()+"' has unrelated validation errors:");
         for (ValidationMessage vm : unexpectedErrors) {
@@ -760,10 +760,11 @@ public class ExampleInspector implements IValidatorResourceFetcher, IValidationP
     }
   }
 
-  static List<ValidationMessage> findUnexpectedInvariantFixtureErrors(String invariantId, List<ValidationMessage> messages) {
+  static List<ValidationMessage> findUnexpectedInvariantFixtureErrors(String fileName, String invariantId, List<ValidationMessage> messages) {
     List<ValidationMessage> result = new ArrayList<>();
+    boolean expectedPass = fileName.contains(".pass");
     for (ValidationMessage message : messages) {
-      if (isError(message) && !isInvariantMessage(message, invariantId)) {
+      if (isError(message) && (expectedPass || !isInvariantMessage(message))) {
         result.add(message);
       }
     }
@@ -772,6 +773,10 @@ public class ExampleInspector implements IValidatorResourceFetcher, IValidationP
 
   private static boolean isInvariantMessage(ValidationMessage message, String invariantId) {
     return message.getMessage() != null && message.getMessage().contains(invariantId+":");
+  }
+
+  private static boolean isInvariantMessage(ValidationMessage message) {
+    return message.getMessage() != null && message.getMessage().startsWith("Constraint failed:");
   }
 
   private static boolean isError(ValidationMessage message) {

--- a/src/main/java/org/hl7/fhir/tools/publisher/ExampleInspector.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/ExampleInspector.java
@@ -729,7 +729,7 @@ public class ExampleInspector implements IValidatorResourceFetcher, IValidationP
         }
       }
 
-      con.setTestOutcome(isInvariantTestSuccessful(f.getName(), inv, errs));
+      con.setTestOutcome(isInvariantTestSuccessful(f.getName(), inv, errs) && unexpectedErrors.isEmpty());
       if (!con.getTestOutcome()) {
         System.out.println("Test case '"+f.getName()+"' invariant test failed: "+con.getId());
         for (ValidationMessage vm : errs) {
@@ -754,17 +754,28 @@ public class ExampleInspector implements IValidatorResourceFetcher, IValidationP
     }
 
     if (expectedPass) {
-      return !foundExpectedInvariantMessage;
+      return !foundExpectedInvariantMessage && findUnexpectedInvariantFixtureErrors(fileName, invariantId, messages).isEmpty();
     } else {
-      return foundExpectedInvariantMessage;
+      return foundExpectedInvariantMessage && findUnexpectedInvariantFixtureErrors(fileName, invariantId, messages).isEmpty();
     }
   }
 
   static List<ValidationMessage> findUnexpectedInvariantFixtureErrors(String fileName, String invariantId, List<ValidationMessage> messages) {
     List<ValidationMessage> result = new ArrayList<>();
     boolean expectedPass = fileName.contains(".pass");
+    List<ValidationMessage> invariantMessages = findInvariantMessages(messages);
     for (ValidationMessage message : messages) {
-      if (isError(message) && (expectedPass || !isInvariantMessage(message))) {
+      if (isError(message) && (expectedPass || !isInvariantMessage(message) && !isCorrelatedWithInvariantMessage(message, invariantMessages))) {
+        result.add(message);
+      }
+    }
+    return result;
+  }
+
+  private static List<ValidationMessage> findInvariantMessages(List<ValidationMessage> messages) {
+    List<ValidationMessage> result = new ArrayList<>();
+    for (ValidationMessage message : messages) {
+      if (isInvariantMessage(message)) {
         result.add(message);
       }
     }
@@ -777,6 +788,31 @@ public class ExampleInspector implements IValidatorResourceFetcher, IValidationP
 
   private static boolean isInvariantMessage(ValidationMessage message) {
     return message.getMessage() != null && message.getMessage().startsWith("Constraint failed:");
+  }
+
+  private static boolean isCorrelatedWithInvariantMessage(ValidationMessage message, List<ValidationMessage> invariantMessages) {
+    String location = normaliseLocation(message.getLocation());
+    if (Utilities.noString(location)) {
+      return false;
+    }
+    for (ValidationMessage invariantMessage : invariantMessages) {
+      String invariantLocation = normaliseLocation(invariantMessage.getLocation());
+      if (pathsOverlap(location, invariantLocation)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String normaliseLocation(String location) {
+    if (location == null) {
+      return "";
+    }
+    return location.replaceAll("\\[[^\\]]*\\]", "");
+  }
+
+  private static boolean pathsOverlap(String left, String right) {
+    return left.equals(right) || left.startsWith(right+".") || right.startsWith(left+".");
   }
 
   private static boolean isError(ValidationMessage message) {

--- a/src/main/java/org/hl7/fhir/tools/publisher/ExampleInspector.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/ExampleInspector.java
@@ -729,7 +729,7 @@ public class ExampleInspector implements IValidatorResourceFetcher, IValidationP
         }
       }
 
-      con.setTestOutcome(isInvariantTestSuccessful(f.getName(), inv, errs) && unexpectedErrors.isEmpty());
+      con.setTestOutcome(isInvariantTestSuccessful(f.getName(), inv, errs));
       if (!con.getTestOutcome()) {
         System.out.println("Test case '"+f.getName()+"' invariant test failed: "+con.getId());
         for (ValidationMessage vm : errs) {
@@ -754,9 +754,9 @@ public class ExampleInspector implements IValidatorResourceFetcher, IValidationP
     }
 
     if (expectedPass) {
-      return !foundExpectedInvariantMessage && findUnexpectedInvariantFixtureErrors(fileName, invariantId, messages).isEmpty();
+      return !foundExpectedInvariantMessage;
     } else {
-      return foundExpectedInvariantMessage && findUnexpectedInvariantFixtureErrors(fileName, invariantId, messages).isEmpty();
+      return foundExpectedInvariantMessage;
     }
   }
 

--- a/src/main/java/org/hl7/fhir/tools/publisher/ExampleInspector.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/ExampleInspector.java
@@ -721,15 +721,17 @@ public class ExampleInspector implements IValidatorResourceFetcher, IValidationP
       validator.setAllowXsiLocation(true);
       validator.validate(null, errs, new FileInputStream(f), fmt);
 
-      boolean fail = false;
-      for (ValidationMessage vm : errs) {
-        if (vm.getMessage().contains(inv+":")) {
-          fail = true;
+      List<ValidationMessage> unexpectedErrors = findUnexpectedInvariantFixtureErrors(inv, errs);
+      if (!unexpectedErrors.isEmpty()) {
+        System.out.println("Test case '"+f.getName()+"' has unrelated validation errors:");
+        for (ValidationMessage vm : unexpectedErrors) {
+          System.out.println("  -- "+vm.summary());
         }
       }
-      con.setTestOutcome(f.getName().contains(".pass") ? !fail : fail);
+
+      con.setTestOutcome(isInvariantTestSuccessful(f.getName(), inv, errs));
       if (!con.getTestOutcome()) {
-        System.out.println("Test case '"+f.getName()+"' Invariant failed: "+con.getId());
+        System.out.println("Test case '"+f.getName()+"' invariant test failed: "+con.getId());
         for (ValidationMessage vm : errs) {
           System.out.println("  -- "+vm.summary());
         }
@@ -739,6 +741,41 @@ public class ExampleInspector implements IValidatorResourceFetcher, IValidationP
       System.out.println("Didn't find invariant for "+f.getName());
       return false;
     }
+  }
+
+  static boolean isInvariantTestSuccessful(String fileName, String invariantId, List<ValidationMessage> messages) {
+    boolean expectedPass = fileName.contains(".pass");
+    boolean foundExpectedInvariantMessage = false;
+
+    for (ValidationMessage message : messages) {
+      if (isInvariantMessage(message, invariantId)) {
+        foundExpectedInvariantMessage = true;
+      }
+    }
+
+    if (expectedPass) {
+      return !foundExpectedInvariantMessage;
+    } else {
+      return foundExpectedInvariantMessage;
+    }
+  }
+
+  static List<ValidationMessage> findUnexpectedInvariantFixtureErrors(String invariantId, List<ValidationMessage> messages) {
+    List<ValidationMessage> result = new ArrayList<>();
+    for (ValidationMessage message : messages) {
+      if (isError(message) && !isInvariantMessage(message, invariantId)) {
+        result.add(message);
+      }
+    }
+    return result;
+  }
+
+  private static boolean isInvariantMessage(ValidationMessage message, String invariantId) {
+    return message.getMessage() != null && message.getMessage().contains(invariantId+":");
+  }
+
+  private static boolean isError(ValidationMessage message) {
+    return message.getLevel() == IssueSeverity.ERROR || message.getLevel() == IssueSeverity.FATAL;
   }
 
   private Invariant findInvInAnyDefinition(String inv) {
@@ -873,5 +910,3 @@ public class ExampleInspector implements IValidatorResourceFetcher, IValidationP
   }
 
 }
-
-

--- a/src/test/java/org/hl7/fhir/tools/publisher/ExampleInspectorTest.java
+++ b/src/test/java/org/hl7/fhir/tools/publisher/ExampleInspectorTest.java
@@ -21,7 +21,7 @@ public class ExampleInspectorTest {
         "cmp-1",
         List.of(message("Search parameter did not find examples", IssueSeverity.INFORMATION))));
 
-    assertTrue(ExampleInspector.isInvariantTestSuccessful(
+    assertFalse(ExampleInspector.isInvariantTestSuccessful(
         "cmp-1.p1.pass.xml",
         "cmp-1",
         List.of(message("Undefined element 'type' at /Composition/relatesTo/type", IssueSeverity.ERROR))));
@@ -39,12 +39,12 @@ public class ExampleInspectorTest {
         "cmp-1",
         List.of(message("Constraint failed: cmp-1: A section must contain at least one of text, entries, or sub-sections", IssueSeverity.WARNING))));
 
-    assertTrue(ExampleInspector.isInvariantTestSuccessful(
+    assertFalse(ExampleInspector.isInvariantTestSuccessful(
         "cmp-1.f1.fail.xml",
         "cmp-1",
         List.of(
-            message("Constraint failed: cmp-1: A section must contain at least one of text, entries, or sub-sections", IssueSeverity.ERROR),
-            message("Undefined element 'type' at /Composition/relatesTo/type", IssueSeverity.ERROR))));
+            messageAt("Composition.section", "Constraint failed: cmp-1: A section must contain at least one of text, entries, or sub-sections", IssueSeverity.ERROR),
+            messageAt("Composition.relatesTo.type", "Undefined element 'type' at /Composition/relatesTo/type", IssueSeverity.ERROR))));
   }
 
   @Test
@@ -56,17 +56,38 @@ public class ExampleInspectorTest {
   }
 
   @Test
+  public void failFixtureAllowsCorrelatedConstraintErrors() {
+    assertTrue(ExampleInspector.isInvariantTestSuccessful(
+        "cmp-1.f1.fail.xml",
+        "cmp-1",
+        List.of(
+            message("Constraint failed: cmp-1: A section must contain at least one of text, entries, or sub-sections", IssueSeverity.ERROR),
+            message("Constraint failed: cmp-3: Sections containing section.text SHALL NOT contain emptyReason", IssueSeverity.ERROR))));
+  }
+
+  @Test
   public void failFixtureUnexpectedErrorsExcludeInvariantMessages() {
     List<ValidationMessage> messages = List.of(
-        message("Constraint failed: cmp-1: A section must contain at least one of text, entries, or sub-sections", IssueSeverity.ERROR),
-        message("Constraint failed: cmp-3: Sections containing section.text SHALL NOT contain emptyReason", IssueSeverity.ERROR),
-        message("Undefined element 'type' at /Composition/relatesTo/type", IssueSeverity.ERROR),
+        messageAt("Composition.section", "Constraint failed: cmp-1: A section must contain at least one of text, entries, or sub-sections", IssueSeverity.ERROR),
+        messageAt("Composition.section", "Constraint failed: cmp-3: Sections containing section.text SHALL NOT contain emptyReason", IssueSeverity.ERROR),
+        messageAt("Composition.relatesTo.type", "Undefined element 'type' at /Composition/relatesTo/type", IssueSeverity.ERROR),
         message("Search parameter did not find examples", IssueSeverity.WARNING));
 
     List<ValidationMessage> unexpectedErrors = ExampleInspector.findUnexpectedInvariantFixtureErrors("cmp-1.f1.fail.xml", "cmp-1", messages);
 
     assertEquals(1, unexpectedErrors.size());
     assertEquals("Undefined element 'type' at /Composition/relatesTo/type", unexpectedErrors.get(0).getMessage());
+  }
+
+  @Test
+  public void failFixtureUnexpectedErrorsAllowSameSubtreeValidatorMessages() {
+    List<ValidationMessage> messages = List.of(
+        messageAt("Bundle", "Constraint failed: bdl-11: A document must have a Composition as the first resource", IssueSeverity.ERROR),
+        messageAt("Bundle.entry.resource", "The first entry in a document must be a composition", IssueSeverity.ERROR));
+
+    List<ValidationMessage> unexpectedErrors = ExampleInspector.findUnexpectedInvariantFixtureErrors("bdl-11.f1.fail.xml", "bdl-11", messages);
+
+    assertEquals(0, unexpectedErrors.size());
   }
 
   @Test
@@ -83,5 +104,9 @@ public class ExampleInspectorTest {
 
   private ValidationMessage message(String message, IssueSeverity severity) {
     return new ValidationMessage(Source.InstanceValidator, IssueType.STRUCTURE, -1, -1, "fixture", message, severity);
+  }
+
+  private ValidationMessage messageAt(String location, String message, IssueSeverity severity) {
+    return new ValidationMessage(Source.InstanceValidator, IssueType.STRUCTURE, -1, -1, location, message, severity);
   }
 }

--- a/src/test/java/org/hl7/fhir/tools/publisher/ExampleInspectorTest.java
+++ b/src/test/java/org/hl7/fhir/tools/publisher/ExampleInspectorTest.java
@@ -21,7 +21,7 @@ public class ExampleInspectorTest {
         "cmp-1",
         List.of(message("Search parameter did not find examples", IssueSeverity.INFORMATION))));
 
-    assertFalse(ExampleInspector.isInvariantTestSuccessful(
+    assertTrue(ExampleInspector.isInvariantTestSuccessful(
         "cmp-1.p1.pass.xml",
         "cmp-1",
         List.of(message("Undefined element 'type' at /Composition/relatesTo/type", IssueSeverity.ERROR))));
@@ -39,7 +39,7 @@ public class ExampleInspectorTest {
         "cmp-1",
         List.of(message("Constraint failed: cmp-1: A section must contain at least one of text, entries, or sub-sections", IssueSeverity.WARNING))));
 
-    assertFalse(ExampleInspector.isInvariantTestSuccessful(
+    assertTrue(ExampleInspector.isInvariantTestSuccessful(
         "cmp-1.f1.fail.xml",
         "cmp-1",
         List.of(

--- a/src/test/java/org/hl7/fhir/tools/publisher/ExampleInspectorTest.java
+++ b/src/test/java/org/hl7/fhir/tools/publisher/ExampleInspectorTest.java
@@ -1,0 +1,74 @@
+package org.hl7.fhir.tools.publisher;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.hl7.fhir.utilities.validation.ValidationMessage;
+import org.hl7.fhir.utilities.validation.ValidationMessage.IssueSeverity;
+import org.hl7.fhir.utilities.validation.ValidationMessage.IssueType;
+import org.hl7.fhir.utilities.validation.ValidationMessage.Source;
+import org.junit.jupiter.api.Test;
+
+public class ExampleInspectorTest {
+
+  @Test
+  public void passFixtureStillDependsOnNamedInvariantMessage() {
+    assertTrue(ExampleInspector.isInvariantTestSuccessful(
+        "cmp-1.p1.pass.xml",
+        "cmp-1",
+        List.of(message("Search parameter did not find examples", IssueSeverity.INFORMATION))));
+
+    assertTrue(ExampleInspector.isInvariantTestSuccessful(
+        "cmp-1.p1.pass.xml",
+        "cmp-1",
+        List.of(message("Undefined element 'type' at /Composition/relatesTo/type", IssueSeverity.ERROR))));
+
+    assertFalse(ExampleInspector.isInvariantTestSuccessful(
+        "cmp-1.p1.pass.xml",
+        "cmp-1",
+        List.of(message("Constraint failed: cmp-1: A section must contain at least one of text, entries, or sub-sections", IssueSeverity.WARNING))));
+  }
+
+  @Test
+  public void failFixtureStillDependsOnNamedInvariantMessage() {
+    assertTrue(ExampleInspector.isInvariantTestSuccessful(
+        "cmp-1.f1.fail.xml",
+        "cmp-1",
+        List.of(message("Constraint failed: cmp-1: A section must contain at least one of text, entries, or sub-sections", IssueSeverity.WARNING))));
+
+    assertTrue(ExampleInspector.isInvariantTestSuccessful(
+        "cmp-1.f1.fail.xml",
+        "cmp-1",
+        List.of(
+            message("Constraint failed: cmp-1: A section must contain at least one of text, entries, or sub-sections", IssueSeverity.ERROR),
+            message("Undefined element 'type' at /Composition/relatesTo/type", IssueSeverity.ERROR))));
+  }
+
+  @Test
+  public void failFixtureDoesNotPassForAnUnrelatedError() {
+    assertFalse(ExampleInspector.isInvariantTestSuccessful(
+        "cmp-1.f1.fail.xml",
+        "cmp-1",
+        List.of(message("Constraint failed: ref-2: Reference must have a value", IssueSeverity.ERROR))));
+  }
+
+  @Test
+  public void unexpectedFixtureErrorsExcludeNamedInvariantMessages() {
+    List<ValidationMessage> messages = List.of(
+        message("Constraint failed: cmp-1: A section must contain at least one of text, entries, or sub-sections", IssueSeverity.ERROR),
+        message("Undefined element 'type' at /Composition/relatesTo/type", IssueSeverity.ERROR),
+        message("Search parameter did not find examples", IssueSeverity.WARNING));
+
+    List<ValidationMessage> unexpectedErrors = ExampleInspector.findUnexpectedInvariantFixtureErrors("cmp-1", messages);
+
+    assertEquals(1, unexpectedErrors.size());
+    assertEquals("Undefined element 'type' at /Composition/relatesTo/type", unexpectedErrors.get(0).getMessage());
+  }
+
+  private ValidationMessage message(String message, IssueSeverity severity) {
+    return new ValidationMessage(Source.InstanceValidator, IssueType.STRUCTURE, -1, -1, "fixture", message, severity);
+  }
+}

--- a/src/test/java/org/hl7/fhir/tools/publisher/ExampleInspectorTest.java
+++ b/src/test/java/org/hl7/fhir/tools/publisher/ExampleInspectorTest.java
@@ -56,16 +56,29 @@ public class ExampleInspectorTest {
   }
 
   @Test
-  public void unexpectedFixtureErrorsExcludeNamedInvariantMessages() {
+  public void failFixtureUnexpectedErrorsExcludeInvariantMessages() {
     List<ValidationMessage> messages = List.of(
         message("Constraint failed: cmp-1: A section must contain at least one of text, entries, or sub-sections", IssueSeverity.ERROR),
+        message("Constraint failed: cmp-3: Sections containing section.text SHALL NOT contain emptyReason", IssueSeverity.ERROR),
         message("Undefined element 'type' at /Composition/relatesTo/type", IssueSeverity.ERROR),
         message("Search parameter did not find examples", IssueSeverity.WARNING));
 
-    List<ValidationMessage> unexpectedErrors = ExampleInspector.findUnexpectedInvariantFixtureErrors("cmp-1", messages);
+    List<ValidationMessage> unexpectedErrors = ExampleInspector.findUnexpectedInvariantFixtureErrors("cmp-1.f1.fail.xml", "cmp-1", messages);
 
     assertEquals(1, unexpectedErrors.size());
     assertEquals("Undefined element 'type' at /Composition/relatesTo/type", unexpectedErrors.get(0).getMessage());
+  }
+
+  @Test
+  public void passFixtureUnexpectedErrorsIncludeInvariantMessages() {
+    List<ValidationMessage> messages = List.of(
+        message("Constraint failed: cmp-3: Sections containing section.text SHALL NOT contain emptyReason", IssueSeverity.ERROR),
+        message("Search parameter did not find examples", IssueSeverity.WARNING));
+
+    List<ValidationMessage> unexpectedErrors = ExampleInspector.findUnexpectedInvariantFixtureErrors("cmp-1.p1.pass.xml", "cmp-1", messages);
+
+    assertEquals(1, unexpectedErrors.size());
+    assertEquals("Constraint failed: cmp-3: Sections containing section.text SHALL NOT contain emptyReason", unexpectedErrors.get(0).getMessage());
   }
 
   private ValidationMessage message(String message, IssueSeverity severity) {


### PR DESCRIPTION
## Summary

Report core FHIR invariant fixture validation errors that are unrelated to the invariant being tested, without changing the existing build-fatal invariant outcome behavior.

Kindling validates files under `source/<resource>/invariant-tests`. The intended contract is:

- `.pass` fixtures should have no validation errors.
- `.fail` fixtures must demonstrate the named invariant/constraint being tested.
- `.fail` fixtures should not contain unrelated validation errors.
- Correlated constraint failures are allowed when the target malformed shape naturally trips sibling invariants or same-subtree validator diagnostics.

This PR makes violations of that contract visible in the publisher log so authors can clean them up in batches.

## Behavior Changed

The existing invariant pass/fail rule is preserved:

- `.pass` fixtures pass the invariant test when the named invariant message is absent.
- `.fail` fixtures pass the invariant test when the named invariant message is present.
- The named invariant is recognized at any severity, matching current behavior.

The new reporting rule is:

- `.pass` fixtures report any `ERROR` or `FATAL` validation message.
- `.fail` fixtures report `ERROR` or `FATAL` messages that are neither invariant constraint messages nor same-subtree validator diagnostics correlated with an invariant failure.
- Additional `Constraint failed:` messages in `.fail` fixtures are allowed, because some negative fixtures necessarily trip correlated sibling invariants.
- Non-`Constraint failed:` validator diagnostics in `.fail` fixtures are allowed only when their location overlaps the same element subtree as an invariant failure.

This PR deliberately does **not** make those extra diagnostics build-fatal. The invariant test still processes all fixture files and reports all detected cases in one run.

## Why This Is Needed

The previous check only asked whether the named invariant signal was present or absent. That meant a fixture could still pass the invariant test while also containing unrelated broken content.

Representative example from the FHIR cleanup branch: several Composition `cmp-*` fixtures were intended to test `Composition.section` invariants, but also contained stale `Composition.relatesTo.type` content from before `relatesTo.type` became `CodeableConcept`.

The fixture still exercised `cmp-1`, `cmp-2`, or `cmp-3`, so the old invariant check passed. Under this PR, that unrelated `Composition.relatesTo` datatype error is reported because it is not an invariant message and it does not overlap the `Composition.section` subtree where the intended invariant failed.

## Correlated Failures

The stricter rule of “only this exact invariant id may appear” was too strong in practice.

Some negative fixtures cannot isolate one invariant perfectly. For example, one malformed resource shape can legitimately trip the target invariant and a sibling invariant from the same constraint family. Those extra `Constraint failed:` diagnostics are accepted for `.fail` fixtures.

Some validator diagnostics are also not formatted as `Constraint failed:` even though they are direct reports for the same invalid shape. Examples found in FHIR core include:

- Bundle first-entry diagnostics alongside `bdl-11` / `bdl-12`.
- Bundle missing `fullUrl` diagnostics alongside `bdl-15`.
- CodeSystem supplement/duplicate-code diagnostics alongside `csd-4` / `csd-1`.
- StructureDefinition snapshot/path diagnostics alongside related `sdf-*` invariants.

The implementation handles these by allowing non-invariant errors only when their reported location overlaps a subtree that also has an invariant failure.

## Local FHIR Verification

I installed this Kindling snapshot locally and ran it against the cleaned FHIR fixture branch `fix-invariant-test-fixture-hygiene`.

Command:

```sh
timeout 240 ./gradlew --no-daemon --refresh-dependencies publish > /tmp/fhir-kindling-invariant-check-2.log 2>&1
```

Result:

- The build used local `org.hl7.fhir:kindling:1.25.5-SNAPSHOT`.
- The invariant phase reached `256 invariants tested (67%)`.
- No `Test case ... invariant test failed` lines were emitted.
- No `Test case ... has unrelated validation errors` lines were emitted.

The `67%` is fixture coverage: 256 invariant ids currently have fixture files out of 381 discovered invariants. It is not an early stop.

## Validator Issues To Investigate Separately

During the FHIR fixture cleanup, ConceptMap `cmd-6` exposed a validator hard-error path: adding apparently valid `additionalAttribute` scaffolding for the helper attribute caused a validator NullPointerException in the XML choice-element path. This PR does not mask that behavior; it belongs in validator triage.

## Tests

```sh
/tmp/apache-maven-3.9.9/bin/mvn -q -Dtest=ExampleInspectorTest test
git diff --check
```
