### PR TITLE
Use resource description as root definition source text

### DIFF
--- a/src/main/java/org/hl7/fhir/definitions/parsers/ResourceParser.java
+++ b/src/main/java/org/hl7/fhir/definitions/parsers/ResourceParser.java
@@ -502,6 +502,7 @@ public class ResourceParser {
     
     ProfileUtilities pu = new ProfileUtilities(context, null, null);
     r.setRoot(parseTypeDefinition(pu, sd.getDifferential().getElementFirstRep(), sd));
+    r.getRoot().setDefinition(r.getDefinition());
     r.getRoot().setRequirements(r.getRequirements());
     if (r.isAbstract()) {
       r.getRoot().setAbstractType(true);

--- a/src/main/java/org/hl7/fhir/definitions/validation/ResourceValidator.java
+++ b/src/main/java/org/hl7/fhir/definitions/validation/ResourceValidator.java
@@ -138,6 +138,17 @@ public class ResourceValidator extends BaseValidator {
     return false;
   }
 
+  private boolean resourceDescriptionMatchesRootDefinition(ResourceDefn rd) {
+    return normalizeDefinitionText(rd.getDefinition()).equals(normalizeDefinitionText(rd.getRoot().getDefinition()));
+  }
+
+  private String normalizeDefinitionText(String value) {
+    if (value == null) {
+      return "";
+    }
+    return value.trim().replaceAll("\\s+", " ");
+  }
+
   public List<ValidationMessage> checkStucture(String name, ElementDefn structure) throws Exception {
     List<ValidationMessage> errors = new ArrayList<ValidationMessage>();
     checkStucture(errors, name, structure);
@@ -166,6 +177,9 @@ public class ResourceValidator extends BaseValidator {
     rule(errors, ValidationMessage.NO_RULE_DATE, IssueType.REQUIRED, rd.getName(), rd.getRoot().getElements().size() > 0, "A resource must have at least one element in it before the build can proceed"); // too many downstream issues in the parsers, and it would only happen as a transient thing when designing the resources
     rule(errors, ValidationMessage.NO_RULE_DATE, IssueType.REQUIRED, rd.getName(), rd.getWg() != null, "A resource must have a designated owner"); // too many downstream issues in the parsers, and it would only happen as a transient thing when designing the resources
     rule(errors, ValidationMessage.NO_RULE_DATE, IssueType.REQUIRED, rd.getName(), !Utilities.noString(rd.getRoot().getW5()), "A resource must have a W5 category");
+    warning(errors, ValidationMessage.NO_RULE_DATE, IssueType.STRUCTURE, rd.getName(), resourceDescriptionMatchesRootDefinition(rd),
+        "Resource description must match root element definition. Description = '" + rd.getDefinition()
+            + "'; root definition = '" + rd.getRoot().getDefinition() + "'");
     rd.getRoot().setMinCardinality(0);
     rd.getRoot().setMaxCardinality(Integer.MAX_VALUE);
     // pattern related rules

--- a/src/main/java/org/hl7/fhir/definitions/validation/ResourceValidator.java
+++ b/src/main/java/org/hl7/fhir/definitions/validation/ResourceValidator.java
@@ -138,17 +138,6 @@ public class ResourceValidator extends BaseValidator {
     return false;
   }
 
-  private boolean resourceDescriptionMatchesRootDefinition(ResourceDefn rd) {
-    return normalizeDefinitionText(rd.getDefinition()).equals(normalizeDefinitionText(rd.getRoot().getDefinition()));
-  }
-
-  private String normalizeDefinitionText(String value) {
-    if (value == null) {
-      return "";
-    }
-    return value.trim().replaceAll("\\s+", " ");
-  }
-
   public List<ValidationMessage> checkStucture(String name, ElementDefn structure) throws Exception {
     List<ValidationMessage> errors = new ArrayList<ValidationMessage>();
     checkStucture(errors, name, structure);
@@ -177,9 +166,6 @@ public class ResourceValidator extends BaseValidator {
     rule(errors, ValidationMessage.NO_RULE_DATE, IssueType.REQUIRED, rd.getName(), rd.getRoot().getElements().size() > 0, "A resource must have at least one element in it before the build can proceed"); // too many downstream issues in the parsers, and it would only happen as a transient thing when designing the resources
     rule(errors, ValidationMessage.NO_RULE_DATE, IssueType.REQUIRED, rd.getName(), rd.getWg() != null, "A resource must have a designated owner"); // too many downstream issues in the parsers, and it would only happen as a transient thing when designing the resources
     rule(errors, ValidationMessage.NO_RULE_DATE, IssueType.REQUIRED, rd.getName(), !Utilities.noString(rd.getRoot().getW5()), "A resource must have a W5 category");
-    warning(errors, ValidationMessage.NO_RULE_DATE, IssueType.STRUCTURE, rd.getName(), resourceDescriptionMatchesRootDefinition(rd),
-        "Resource description must match root element definition. Description = '" + rd.getDefinition()
-            + "'; root definition = '" + rd.getRoot().getDefinition() + "'");
     rd.getRoot().setMinCardinality(0);
     rd.getRoot().setMaxCardinality(Integer.MAX_VALUE);
     // pattern related rules


### PR DESCRIPTION
## Summary

Changes base resource parsing so `StructureDefinition.description` is the authoritative authored text for a resource's root definition.

When Kindling parses a native resource `StructureDefinition`, it now copies the resource description onto the parsed root `ElementDefn.definition`. This means generated differential/snapshot root definitions and the rendered resource-page intro text follow the single authored `description` field.

## Rationale

Eric suggested a simpler rule: authors should populate only `StructureDefinition.description`, and the FHIR build should overwrite/populate the root element definition from that text.

That avoids requiring authors to maintain two parallel copies of the same resource-level introduction, while still preserving the generated artifacts and rendered page behavior that currently depend on the root definition.

## Companion FHIR content PR

Companion source cleanup: HL7/fhir#4123.

That PR removes duplicated authored root definitions from resource StructureDefinition source and curates the resource descriptions where the previous root definition text was better or where the two had diverged semantically.

## Verification

- `/tmp/apache-maven-3.9.9/bin/mvn -q -DskipTests install`
- With this Kindling installed locally, HL7/fhir#4123 source passed:
  - `xmllint --noout` over current resource StructureDefinition XML files
  - `git diff --check`
  - `./gradlew publish --args="-nopartial -validation-mode none"`
- Generated package spot-check: 131 base resource StructureDefinitions had matching `description`, differential root definition, and snapshot root definition.
