### PR TITLE
Removed code that was setting the name-misalignment reason to 'unknow…

### DIFF
--- a/src/main/java/org/hl7/fhir/tools/publisher/PageProcessor.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/PageProcessor.java
@@ -7129,9 +7129,11 @@ public class PageProcessor implements Logger, ProfileKnowledgeProvider, IReferen
       sj.add(resource.getPath()+" : "+resource.typeSummary()+" ["+resource.getMin()+".."+resource.getMax()+"]");
     else 
       sj.add("<li>"+resource.getPath()+" : "+resource.typeSummary()+" ["+resource.getMin()+".."+resource.getMax()+"]</li>");
-    if (!logical.getName().equals(edPathTail(resource.getPath()))) {
+/* 
+ * Don't yell about name reasons because there are too many situations where names are legitimately different
+ *    if (!logical.getName().equals(edPathTail(resource.getPath()))) {
       info.nameReason = REASON_UNKNOWN;
-    }
+    }*/
     checkCardinality(logical, light, resource, info, exception, newException, doc, sj);
     if (!light)
       checkType(logical, light, resource, cm, info, exception, newException, doc, sj);


### PR DESCRIPTION
…n' because we don't actually show name misalignment anywhere, and it was triggering a warning that there were unknown reasons specified, even though none were visible in the file.  Commented rather than removing because I don't remember why I wrote the name matching stuff originally and want to leave the remnants in case we ever decide to do something more useful with it.