### PR TITLE
Update okio and kotlin-stdlib versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <maven.compiler.testRelease>17</maven.compiler.testRelease>
         <maven.compiler.testSource>17</maven.compiler.testSource>
         <maven.compiler.testTarget>17</maven.compiler.testTarget>
+        <okio.version>3.16.4</okio.version>
     </properties>
 
     <repositories>
@@ -83,18 +84,18 @@
             <dependency>
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio</artifactId>
-                <version>3.4.0</version>
+                <version>${okio.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio-jvm</artifactId>
-                <version>3.4.0</version>
+                <version>${okio.version}</version>
             </dependency>
             <!-- Fixes older 2.2.20 in okio-->
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib</artifactId>
-                <version>2.2.21</version>
+                <version>2.4.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-beanutils</groupId>


### PR DESCRIPTION
Update okio and kotlin-stdlib versions to fix mismatch with current org.hl7.fhir.core