### PR TITLE
2026-07-31 dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     <properties>
         <fhirCoreVersion>6.9.12-SNAPSHOT</fhirCoreVersion>
         <apachePoiVersion>5.4.1</apachePoiVersion>
-        <jacksonAnnotationsVersion>2.21</jacksonAnnotationsVersion>
-        <jacksonVersion>2.21.3</jacksonVersion>
+        <jacksonAnnotationsVersion>2.22</jacksonAnnotationsVersion>
+        <jacksonVersion>2.22.1</jacksonVersion>
         <apacheHttpcomponentsVersion>4.5.13</apacheHttpcomponentsVersion>
         <apacheHttpcomponents5Version>5.0.4</apacheHttpcomponents5Version>
         <apacheJenaVersion>5.6.0</apacheJenaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,11 @@
         <apacheHttpcomponentsVersion>4.5.13</apacheHttpcomponentsVersion>
         <apacheHttpcomponents5Version>5.0.4</apacheHttpcomponents5Version>
         <apacheJenaVersion>5.6.0</apacheJenaVersion>
-        <log4jVersion>2.26.0</log4jVersion>
+        <log4jVersion>2.26.1</log4jVersion>
         <lombok_version>1.18.38</lombok_version>
         <slf4jVersion>1.7.36</slf4jVersion>
         <jettyVersion>12.0.33</jettyVersion>
-        <logbackVersion>1.5.25</logbackVersion>
+        <logbackVersion>1.5.37</logbackVersion>
         <nettyConstrainedVersion>4.1.118.Final</nettyConstrainedVersion>
         <maven.compiler.release>17</maven.compiler.release>
         <maven.compiler.source>17</maven.compiler.source>
@@ -56,7 +56,7 @@
             <id>github-releases</id>
             <url>https://maven.pkg.github.com/hapifhir/org.hl7.fhir.core/</url>
         </repository>
-<repository>
+        <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
             <snapshots>
@@ -146,6 +146,34 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
                 <version>${log4jVersion}</version>
+            </dependency>
+            <!-- We are not using opentelemetry in this project; this is here to override inherited dependencies that
+                contain vulnerabilities
+            -->
+            <dependency>
+                <groupId>io.opentelemetry.javaagent</groupId>
+                <artifactId>opentelemetry-testing-common</artifactId>
+                <version>2.27.0-alpha</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.javaagent</groupId>
+                <artifactId>opentelemetry-agent-for-testing</artifactId>
+                <version>2.27.0-alpha</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-instrumentation-annotations</artifactId>
+                <version>2.27.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-api</artifactId>
+                <version>1.62.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-context</artifactId>
+                <version>1.62.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -339,7 +367,7 @@
         <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
-            <version>10.3</version>
+            <version>13.0</version>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>


### PR DESCRIPTION
Updates

jackson -> 2.22.1
jackson-annotations -> 2.22
log4j -> 2.26.1
logback -> 1.5.25
saxon-he -> 13.0

Also override unused opentelemetry
api -> 1.62.0
agent -> 2.27.0

This has run successfully on a local build, with the same error/warning/hint counts as the main branch.

```log
Errors: 0 Warnings: 82 Hints: 632

===Resources with FMM forced to 0===
HL7 International / Biomedical Research and Regulation:
  AdministrableProductDefinition(2), ClinicalUseDefinition(2), Ingredient(2), ManufacturedItemDefinition(2), MedicinalProductDefinition(3), PackagedProductDefinition(2), Substance(2), SubstanceDefinition(1)
HL7 International / FHIR Infrastructure:
  ActorDefinition(1), CapabilityStatement(5), CompartmentDefinition(3), DomainResource(5), ExampleScenario(1), Group(3), ImplementationGuide(4), List(4), OperationDefinition(5), Questionnaire(5), QuestionnaireResponse(5), Requirements(1), Resource(5), SearchParameter(5), StructureDefinition(5), Subscription(3), SubscriptionStatus(2), SubscriptionTopic(2)
HL7 International / Financial Management:
  Claim(2), ClaimResponse(2), Coverage(4), CoverageEligibilityRequest(4), CoverageEligibilityResponse(4), ExplanationOfBenefit(2), PaymentNotice(4), PaymentReconciliation(4)
HL7 International / Orders and Observations:
  BiologicallyDerivedProduct(2), BodyStructure(1), Device(2), DeviceDefinition(1), DeviceRequest(1), DiagnosticReport(3), DocumentReference(5), NutritionIntake(3), NutritionOrder(3), NutritionProduct(3), Observation(5), ObservationDefinition(1), ServiceRequest(4), Specimen(3), SpecimenDefinition(1), Task(4), VisionPrescription(3)
HL7 International / Patient Administration:
  Appointment(3), AppointmentResponse(3), Encounter(4), EpisodeOfCare(2), HealthcareService(4), Location(5), Organization(5), OrganizationAffiliation(1), Patient(5), Practitioner(5), PractitionerRole(4), RelatedPerson(5)
HL7 International / Patient Care:
  AdverseEvent(2), AllergyIntolerance(3), CarePlan(2), CareTeam(2), Communication(2), CommunicationRequest(2), Condition(5), FamilyMemberHistory(2), Goal(2), Procedure(4)
HL7 International / Terminology Infrastructure:
  CodeSystem(5), ConceptMap(3), NamingSystem(4), TerminologyCapabilities(1)
    1.869 1477sec 2247MB
Max Memory Used = 3Gb                                                         0.057 1477sec 2287MB
This was a Full Build                                                         0.001 1477sec 2287MB
hl7.fhir.r6.core         : hl7.fhir.r6.core#6.0.0-ballot4 = http://hl7.org/fhir @ file:/Users/user/IdeaFhirCoreLibraries/fhir/publish/. FHIR Core package - the NPM package that contains all the definitions for the base FHIR specification (built Fri, Jul 31, 2026 13:53-0400-04:00)
  other: 470
  package: 2694
  openapi: 1
  xml: 270
hl7.fhir.r6.expansions   : hl7.fhir.r6.expansions#6.0.0-ballot4 = http://hl7.org/fhir @ file:/Users/user/IdeaFhirCoreLibraries/fhir/publish/. Expansions for the 6.0.0-ballot4 version of the FHIR standard (built Fri, Jul 31, 2026 13:53-0400-04:00)
  package: 722
hl7.fhir.r6.examples     : hl7.fhir.r6.examples#6.0.0-ballot4 = http://hl7.org/fhir @ file:/Users/user/IdeaFhirCoreLibraries/fhir/publish/. Examples for the 6.0.0-ballot4 version of the FHIR standard (built Fri, Jul 31, 2026 13:53-0400-04:00)
  package: 2324
hl7.fhir.r6.search       : hl7.fhir.r6.search#6.0.0-ballot4 = http://hl7.org/fhir @ file:/Users/user/IdeaFhirCoreLibraries/fhir/publish/. FHIR 6.0.0-ballot4 package : Search Parameters (break out combined parameters for server execution convenience) (built Fri, Jul 31, 2026 13:53-0400-04:00)
  package: 1883
hl7.fhir.r6.corexml      : hl7.fhir.r6.corexml#6.0.0-ballot4 = http://hl7.org/fhir @ file:/Users/user/IdeaFhirCoreLibraries/fhir/publish/. FHIR Core package - the NPM package that contains all the definitions for the base FHIR specification (XML) (built Fri, Jul 31, 2026 13:53-0400-04:00)
  other: 1
  package: 2602
Finished publishing FHIR @ Fri, Jul 31, 2026 14:18-0400                       1.473 1479sec 3717MB

Process finished with exit code 0

```